### PR TITLE
beginning of advanced CloudWatch integration

### DIFF
--- a/micronaut-aws-sdk/src/main/groovy/com/agorapulse/micronaut/aws/cloudwatch/CloudWatchExtensions.java
+++ b/micronaut-aws-sdk/src/main/groovy/com/agorapulse/micronaut/aws/cloudwatch/CloudWatchExtensions.java
@@ -18,11 +18,20 @@ public class CloudWatchExtensions {
 
     public static void putMetrics(
         CloudWatchService service,
+        @DelegatesTo(value = MetricData.class, strategy = Closure.DELEGATE_FIRST)
+        @ClosureParams(value = SimpleType.class, options = "com.agorapulse.micronaut.aws.cloudwatch.MetricData")
+            Closure<MetricData> builder
+    ) {
+        service.putMetrics(ConsumerWithDelegate.create(builder));
+    }
+
+    public static MetricData metric(
+        MetricData data,
         @DelegatesTo(value = MetricDatum.class, strategy = Closure.DELEGATE_FIRST)
         @ClosureParams(value = SimpleType.class, options = "com.amazonaws.services.cloudwatch.model.MetricDatum")
             Closure<MetricDatum> builder
     ) {
-        service.putMetrics(ConsumerWithDelegate.create(builder));
+        return data.metric(ConsumerWithDelegate.create(builder));
     }
 
     public static MetricDatum name(MetricDatum datum, String metricName) {
@@ -62,13 +71,17 @@ public class CloudWatchExtensions {
         return datum.withStatisticValues(stats);
     }
 
-    public static MetricDatum values(MetricDatum datum, Double... values) {
+    public static MetricDatum values(MetricDatum datum, List<Double> values) {
         if (datum.getValues() == null) {
             datum.withValues(values);
         } else {
-            datum.getValues().addAll(Arrays.asList(values));
+            datum.getValues().addAll(values);
         }
         return datum;
+    }
+
+    public static MetricDatum values(MetricDatum datum, Double... values) {
+        return values(datum, Arrays.asList(values));
     }
 
     public static MetricDatum data(MetricDatum datum, Double value) {
@@ -82,6 +95,10 @@ public class CloudWatchExtensions {
     }
 
     public static MetricDatum counts(MetricDatum datum, Double... counts) {
+        return datum.withCounts(counts);
+    }
+
+    public static MetricDatum counts(MetricDatum datum, List<Double> counts) {
         return datum.withCounts(counts);
     }
 

--- a/micronaut-aws-sdk/src/main/groovy/com/agorapulse/micronaut/aws/cloudwatch/CloudWatchExtensions.java
+++ b/micronaut-aws-sdk/src/main/groovy/com/agorapulse/micronaut/aws/cloudwatch/CloudWatchExtensions.java
@@ -1,0 +1,221 @@
+package com.agorapulse.micronaut.aws.cloudwatch;
+
+import com.amazonaws.services.cloudwatch.model.Dimension;
+import com.amazonaws.services.cloudwatch.model.MetricDatum;
+import com.amazonaws.services.cloudwatch.model.StandardUnit;
+import com.amazonaws.services.cloudwatch.model.StatisticSet;
+import groovy.lang.Closure;
+import groovy.lang.DelegatesTo;
+import groovy.transform.stc.ClosureParams;
+import groovy.transform.stc.SimpleType;
+import space.jasan.support.groovy.closure.ConsumerWithDelegate;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+public class CloudWatchExtensions {
+
+    public static void putMetrics(
+        CloudWatchService service,
+        @DelegatesTo(value = MetricDatum.class, strategy = Closure.DELEGATE_FIRST)
+        @ClosureParams(value = SimpleType.class, options = "com.amazonaws.services.cloudwatch.model.MetricDatum")
+            Closure<MetricDatum> builder
+    ) {
+        service.putMetrics(ConsumerWithDelegate.create(builder));
+    }
+
+    public static MetricDatum name(MetricDatum datum, String metricName) {
+        return datum.withMetricName(metricName);
+    }
+
+    public static MetricDatum labels(MetricDatum datum, String name, String value) {
+        return dimension(datum, name, value);
+    }
+
+    public static MetricDatum dimension(MetricDatum datum, String name, String value) {
+        Dimension dimension = new Dimension().withName(name).withValue(value);
+        if (datum.getDimensions() == null) {
+            datum.withDimensions(dimension);
+        } else {
+            datum.getDimensions().add(dimension);
+        }
+        return datum;
+    }
+
+    public static MetricDatum timestamp(MetricDatum datum, Date timestamp) {
+        return datum.withTimestamp(timestamp);
+    }
+
+    public static MetricDatum value(MetricDatum datum, Double value) {
+        return datum.withValue(value);
+    }
+
+    public static MetricDatum statisticValues(
+        MetricDatum datum,
+        @DelegatesTo(value = StatisticSet.class, strategy = Closure.DELEGATE_FIRST)
+        @ClosureParams(value = SimpleType.class, options = "com.amazonaws.services.cloudwatch.model.StatisticSet")
+            Closure<StatisticSet> statisticValues
+    ) {
+        StatisticSet stats = new StatisticSet();
+        ConsumerWithDelegate.create(statisticValues).accept(stats);
+        return datum.withStatisticValues(stats);
+    }
+
+    public static MetricDatum values(MetricDatum datum, Double... values) {
+        if (datum.getValues() == null) {
+            datum.withValues(values);
+        } else {
+            datum.getValues().addAll(Arrays.asList(values));
+        }
+        return datum;
+    }
+
+    public static MetricDatum data(MetricDatum datum, Double value) {
+        return values(datum, value);
+    }
+
+    public static MetricDatum data(MetricDatum datum, Double value, Double count) {
+        values(datum, value);
+        counts(datum, count);
+        return datum;
+    }
+
+    public static MetricDatum counts(MetricDatum datum, Double... counts) {
+        return datum.withCounts(counts);
+    }
+
+    public static MetricDatum unit(MetricDatum datum, StandardUnit unit) {
+        return datum.withUnit(unit);
+    }
+
+    public static MetricDatum storageResolution(MetricDatum datum, Integer storageResolution) {
+        return datum.withStorageResolution(storageResolution);
+    }
+
+    public static StatisticSet sampleCount(StatisticSet stats, Double sampleCount) {
+        return stats.withSampleCount(sampleCount);
+    }
+
+    public static StatisticSet sum(StatisticSet stats, Double sum) {
+        return stats.withSum(sum);
+    }
+
+    public static StatisticSet minimum(StatisticSet stats, Double minimum) {
+        return stats.withMinimum(minimum);
+    }
+
+    public static StatisticSet maximum(StatisticSet stats, Double maximum) {
+        return stats.withMaximum(maximum);
+    }
+
+    public static StandardUnit getSeconds(MetricDatum datum) {
+        return StandardUnit.Seconds;
+    }
+
+    public static StandardUnit getMicroseconds(MetricDatum datum) {
+        return StandardUnit.Microseconds;
+    }
+
+    public static StandardUnit getMilliseconds(MetricDatum datum) {
+        return StandardUnit.Milliseconds;
+    }
+
+    public static StandardUnit getBytes(MetricDatum datum) {
+        return StandardUnit.Bytes;
+    }
+
+    public static StandardUnit getKilobytes(MetricDatum datum) {
+        return StandardUnit.Kilobytes;
+    }
+
+    public static StandardUnit getMegabytes(MetricDatum datum) {
+        return StandardUnit.Megabytes;
+    }
+
+    public static StandardUnit getGigabytes(MetricDatum datum) {
+        return StandardUnit.Gigabytes;
+    }
+
+    public static StandardUnit getTerabytes(MetricDatum datum) {
+        return StandardUnit.Terabytes;
+    }
+
+    public static StandardUnit getBits(MetricDatum datum) {
+        return StandardUnit.Bits;
+    }
+
+    public static StandardUnit getKilobits(MetricDatum datum) {
+        return StandardUnit.Kilobits;
+    }
+
+    public static StandardUnit getMegabits(MetricDatum datum) {
+        return StandardUnit.Megabits;
+    }
+
+    public static StandardUnit getGigabits(MetricDatum datum) {
+        return StandardUnit.Gigabits;
+    }
+
+    public static StandardUnit getTerabits(MetricDatum datum) {
+        return StandardUnit.Terabits;
+    }
+
+    public static StandardUnit getPercent(MetricDatum datum) {
+        return StandardUnit.Percent;
+    }
+
+    public static StandardUnit getCount(MetricDatum datum) {
+        return StandardUnit.Count;
+    }
+
+    public static StandardUnit getBytesSecond(MetricDatum datum) {
+        return StandardUnit.BytesSecond;
+    }
+
+    public static StandardUnit getKilobytesSecond(MetricDatum datum) {
+        return StandardUnit.KilobytesSecond;
+    }
+
+    public static StandardUnit getMegabytesSecond(MetricDatum datum) {
+        return StandardUnit.MegabytesSecond;
+    }
+
+    public static StandardUnit getGigabytesSecond(MetricDatum datum) {
+        return StandardUnit.GigabytesSecond;
+    }
+
+    public static StandardUnit getTerabytesSecond(MetricDatum datum) {
+        return StandardUnit.TerabytesSecond;
+    }
+
+    public static StandardUnit getBitsSecond(MetricDatum datum) {
+        return StandardUnit.BitsSecond;
+    }
+
+    public static StandardUnit getKilobitsSecond(MetricDatum datum) {
+        return StandardUnit.KilobitsSecond;
+    }
+
+    public static StandardUnit getMegabitsSecond(MetricDatum datum) {
+        return StandardUnit.MegabitsSecond;
+    }
+
+    public static StandardUnit getGigabitsSecond(MetricDatum datum) {
+        return StandardUnit.GigabitsSecond;
+    }
+
+    public static StandardUnit getTerabitsSecond(MetricDatum datum) {
+        return StandardUnit.TerabitsSecond;
+    }
+
+    public static StandardUnit getCountSecond(MetricDatum datum) {
+        return StandardUnit.CountSecond;
+    }
+
+    public static StandardUnit getNone(MetricDatum datum) {
+        return StandardUnit.None;
+    }
+
+
+}

--- a/micronaut-aws-sdk/src/main/groovy/com/agorapulse/micronaut/aws/cloudwatch/CloudWatchFactory.java
+++ b/micronaut-aws-sdk/src/main/groovy/com/agorapulse/micronaut/aws/cloudwatch/CloudWatchFactory.java
@@ -5,10 +5,7 @@ import com.amazonaws.regions.AwsRegionProvider;
 import com.amazonaws.services.cloudwatch.AmazonCloudWatch;
 import com.amazonaws.services.cloudwatch.AmazonCloudWatchClientBuilder;
 import io.micronaut.configuration.aws.AWSClientConfiguration;
-import io.micronaut.context.annotation.Bean;
-import io.micronaut.context.annotation.Factory;
-import io.micronaut.context.annotation.Requires;
-import io.micronaut.context.annotation.Value;
+import io.micronaut.context.annotation.*;
 
 import javax.inject.Singleton;
 import java.util.Optional;
@@ -35,6 +32,11 @@ public class CloudWatchFactory {
             .withRegion(region.orElseGet(awsRegionProvider::getRegion))
             .withClientConfiguration(clientConfiguration.getClientConfiguration())
             .build();
+    }
+
+    @EachBean(DefaultCloudWatchConfiguration.class)
+    CloudWatchService cloudWatchService(DefaultCloudWatchConfiguration configuration, AmazonCloudWatch client) {
+        return new DefaultCloudWatchService(configuration, client);
     }
 
 }

--- a/micronaut-aws-sdk/src/main/groovy/com/agorapulse/micronaut/aws/cloudwatch/CloudWatchService.java
+++ b/micronaut-aws-sdk/src/main/groovy/com/agorapulse/micronaut/aws/cloudwatch/CloudWatchService.java
@@ -1,10 +1,15 @@
 package com.agorapulse.micronaut.aws.cloudwatch;
 
 import com.amazonaws.services.cloudwatch.model.Metric;
+import com.amazonaws.services.cloudwatch.model.MetricDatum;
 import io.reactivex.Flowable;
+
+import java.util.function.Consumer;
 
 public interface CloudWatchService {
 
     Flowable<Metric> getMetrics();
+
+    void putMetrics(Consumer<MetricDatum> builder);
 
 }

--- a/micronaut-aws-sdk/src/main/groovy/com/agorapulse/micronaut/aws/cloudwatch/CloudWatchService.java
+++ b/micronaut-aws-sdk/src/main/groovy/com/agorapulse/micronaut/aws/cloudwatch/CloudWatchService.java
@@ -1,0 +1,10 @@
+package com.agorapulse.micronaut.aws.cloudwatch;
+
+import com.amazonaws.services.cloudwatch.model.Metric;
+import io.reactivex.Flowable;
+
+public interface CloudWatchService {
+
+    Flowable<Metric> getMetrics();
+
+}

--- a/micronaut-aws-sdk/src/main/groovy/com/agorapulse/micronaut/aws/cloudwatch/CloudWatchService.java
+++ b/micronaut-aws-sdk/src/main/groovy/com/agorapulse/micronaut/aws/cloudwatch/CloudWatchService.java
@@ -1,7 +1,6 @@
 package com.agorapulse.micronaut.aws.cloudwatch;
 
 import com.amazonaws.services.cloudwatch.model.Metric;
-import com.amazonaws.services.cloudwatch.model.MetricDatum;
 import io.reactivex.Flowable;
 
 import java.util.function.Consumer;
@@ -10,6 +9,6 @@ public interface CloudWatchService {
 
     Flowable<Metric> getMetrics();
 
-    void putMetrics(Consumer<MetricDatum> builder);
+    void putMetrics(Consumer<MetricData> builder);
 
 }

--- a/micronaut-aws-sdk/src/main/groovy/com/agorapulse/micronaut/aws/cloudwatch/DefaultCloudWatchConfiguration.groovy
+++ b/micronaut-aws-sdk/src/main/groovy/com/agorapulse/micronaut/aws/cloudwatch/DefaultCloudWatchConfiguration.groovy
@@ -1,0 +1,18 @@
+package com.agorapulse.micronaut.aws.cloudwatch
+
+import com.amazonaws.services.cloudwatch.AmazonCloudWatch
+import groovy.transform.CompileStatic
+import io.micronaut.context.annotation.ConfigurationProperties
+import io.micronaut.context.annotation.Requires
+
+import javax.inject.Named
+
+@CompileStatic
+@Named('default')
+@ConfigurationProperties('aws.cloudwatch')
+@Requires(classes = AmazonCloudWatch)
+class DefaultCloudWatchConfiguration {
+
+    String namespace
+
+}

--- a/micronaut-aws-sdk/src/main/groovy/com/agorapulse/micronaut/aws/cloudwatch/DefaultCloudWatchService.java
+++ b/micronaut-aws-sdk/src/main/groovy/com/agorapulse/micronaut/aws/cloudwatch/DefaultCloudWatchService.java
@@ -45,11 +45,11 @@ public class DefaultCloudWatchService implements CloudWatchService {
     }
 
     @Override
-    public void putMetrics(Consumer<MetricDatum> builder) {
-        MetricDatum datum = new MetricDatum();
-        builder.accept(datum);
+    public void putMetrics(Consumer<MetricData> builder) {
+        MetricData data = new MetricData();
+        builder.accept(data);
         PutMetricDataRequest request = new PutMetricDataRequest()
-            .withMetricData(datum)
+            .withMetricData(data.getData())
             .withNamespace(configuration.getNamespace());
         client.putMetricData(request);
     }

--- a/micronaut-aws-sdk/src/main/groovy/com/agorapulse/micronaut/aws/cloudwatch/DefaultCloudWatchService.java
+++ b/micronaut-aws-sdk/src/main/groovy/com/agorapulse/micronaut/aws/cloudwatch/DefaultCloudWatchService.java
@@ -1,0 +1,47 @@
+package com.agorapulse.micronaut.aws.cloudwatch;
+
+import com.amazonaws.services.cloudwatch.AmazonCloudWatch;
+import com.amazonaws.services.cloudwatch.model.ListMetricsRequest;
+import com.amazonaws.services.cloudwatch.model.ListMetricsResult;
+import com.amazonaws.services.cloudwatch.model.Metric;
+import io.reactivex.Emitter;
+import io.reactivex.Flowable;
+
+import java.util.List;
+
+public class DefaultCloudWatchService implements CloudWatchService {
+
+    private static class ListMetricsState {
+        String nextToken;
+    }
+
+    private final DefaultCloudWatchConfiguration configuration;
+    private final AmazonCloudWatch client;
+
+    public DefaultCloudWatchService(DefaultCloudWatchConfiguration configuration, AmazonCloudWatch client) {
+        this.configuration = configuration;
+        this.client = client;
+    }
+
+    @Override
+    public Flowable<Metric> getMetrics() {
+        return Flowable.generate(ListMetricsState::new, (ListMetricsState state, Emitter<List<Metric>> emitter) -> {
+            try {
+                ListMetricsRequest listMetricsRequest = new ListMetricsRequest()
+                    .withNamespace(configuration.getNamespace())
+                    .withNextToken(state.nextToken);
+
+                ListMetricsResult result = client.listMetrics(listMetricsRequest);
+                emitter.onNext(result.getMetrics());
+
+                if (result.getNextToken() == null) {
+                    emitter.onComplete();
+                } else {
+                    state.nextToken = result.getNextToken();
+                }
+            } catch (Exception e) {
+                emitter.onError(e);
+            }
+        }).flatMap(Flowable::fromIterable);
+    }
+}

--- a/micronaut-aws-sdk/src/main/groovy/com/agorapulse/micronaut/aws/cloudwatch/DefaultCloudWatchService.java
+++ b/micronaut-aws-sdk/src/main/groovy/com/agorapulse/micronaut/aws/cloudwatch/DefaultCloudWatchService.java
@@ -1,13 +1,12 @@
 package com.agorapulse.micronaut.aws.cloudwatch;
 
 import com.amazonaws.services.cloudwatch.AmazonCloudWatch;
-import com.amazonaws.services.cloudwatch.model.ListMetricsRequest;
-import com.amazonaws.services.cloudwatch.model.ListMetricsResult;
-import com.amazonaws.services.cloudwatch.model.Metric;
+import com.amazonaws.services.cloudwatch.model.*;
 import io.reactivex.Emitter;
 import io.reactivex.Flowable;
 
 import java.util.List;
+import java.util.function.Consumer;
 
 public class DefaultCloudWatchService implements CloudWatchService {
 
@@ -43,5 +42,15 @@ public class DefaultCloudWatchService implements CloudWatchService {
                 emitter.onError(e);
             }
         }).flatMap(Flowable::fromIterable);
+    }
+
+    @Override
+    public void putMetrics(Consumer<MetricDatum> builder) {
+        MetricDatum datum = new MetricDatum();
+        builder.accept(datum);
+        PutMetricDataRequest request = new PutMetricDataRequest()
+            .withMetricData(datum)
+            .withNamespace(configuration.getNamespace());
+        client.putMetricData(request);
     }
 }

--- a/micronaut-aws-sdk/src/main/groovy/com/agorapulse/micronaut/aws/cloudwatch/MetricData.java
+++ b/micronaut-aws-sdk/src/main/groovy/com/agorapulse/micronaut/aws/cloudwatch/MetricData.java
@@ -1,0 +1,23 @@
+package com.agorapulse.micronaut.aws.cloudwatch;
+
+import com.amazonaws.services.cloudwatch.model.MetricDatum;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+public class MetricData {
+
+    private final List<MetricDatum> data = new ArrayList<>();
+
+    MetricData metric(Consumer<MetricDatum> datum) {
+        MetricDatum d = new MetricDatum();
+        datum.accept(d);
+        data.add(d);
+        return this;
+    }
+
+    public List<MetricDatum> getData() {
+        return data;
+    }
+}

--- a/micronaut-aws-sdk/src/main/groovy/com/agorapulse/micronaut/aws/cloudwatch/NamedCloudWatchConfiguration.groovy
+++ b/micronaut-aws-sdk/src/main/groovy/com/agorapulse/micronaut/aws/cloudwatch/NamedCloudWatchConfiguration.groovy
@@ -1,0 +1,23 @@
+package com.agorapulse.micronaut.aws.cloudwatch
+
+import com.amazonaws.services.cloudwatch.AmazonCloudWatch
+import groovy.transform.CompileStatic
+import io.micronaut.context.annotation.ConfigurationProperties
+import io.micronaut.context.annotation.EachProperty
+import io.micronaut.context.annotation.Parameter
+import io.micronaut.context.annotation.Requires
+
+import javax.inject.Named
+
+@CompileStatic
+@EachProperty('aws.cloudwatch.namespaces')
+@Requires(classes = AmazonCloudWatch, property = 'aws.cloudwatch.namespaces')
+class NamedCloudWatchConfiguration {
+
+    final String name
+
+    NamedCloudWatchConfiguration(@Parameter String name) {
+        this.name = name
+    }
+
+}

--- a/micronaut-aws-sdk/src/main/resources/META-INF/services/org.codehaus.groovy.runtime.ExtensionModule
+++ b/micronaut-aws-sdk/src/main/resources/META-INF/services/org.codehaus.groovy.runtime.ExtensionModule
@@ -1,0 +1,3 @@
+moduleName=micornaut-aws-sdk
+moduleVersion=1.0.4.4
+extensionClasses=com.agorapulse.micronaut.aws.cloudwatch.CloudWatchExtensions

--- a/micronaut-aws-sdk/src/test/groovy/com/agorapulse/micronaut/aws/cloudwatch/CloudWatchServiceSpec.groovy
+++ b/micronaut-aws-sdk/src/test/groovy/com/agorapulse/micronaut/aws/cloudwatch/CloudWatchServiceSpec.groovy
@@ -41,4 +41,21 @@ class CloudWatchServiceSpec extends Specification {
 
     }
 
+    void 'put metrics'() {
+        when:
+            service.putMetrics {
+                name METRIC_NAME
+
+                unit count
+
+                labels 'DIM_NAME', 'DIM_VALUE'
+
+                data 12, 2
+                data 34, 1
+                data 65, 4
+            }
+        then:
+            noExceptionThrown()
+    }
+
 }

--- a/micronaut-aws-sdk/src/test/groovy/com/agorapulse/micronaut/aws/cloudwatch/CloudWatchServiceSpec.groovy
+++ b/micronaut-aws-sdk/src/test/groovy/com/agorapulse/micronaut/aws/cloudwatch/CloudWatchServiceSpec.groovy
@@ -1,0 +1,44 @@
+package com.agorapulse.micronaut.aws.cloudwatch
+
+import com.amazonaws.services.cloudwatch.AmazonCloudWatch
+import com.amazonaws.services.cloudwatch.model.ListMetricsRequest
+import com.amazonaws.services.cloudwatch.model.ListMetricsResult
+import com.amazonaws.services.cloudwatch.model.Metric
+import spock.lang.Specification
+
+class CloudWatchServiceSpec extends Specification {
+
+    public static final String NAMESPACE = "gr8conf"
+    public static final String METRIC_NAME = 'hackergarten'
+    public static final String NEXT_TOKEN = 'next-token'
+
+    AmazonCloudWatch client = Mock()
+    CloudWatchService service = new DefaultCloudWatchService(
+        new DefaultCloudWatchConfiguration(namespace: NAMESPACE),
+        client
+    )
+
+    void 'list metrics'() {
+        when:
+            List<Metric> metrics = service.getMetrics().toList().blockingGet()
+        then:
+            metrics
+            metrics.size() == 2
+
+            1 * client.listMetrics({ ListMetricsRequest r ->
+                r.namespace == NAMESPACE && !r.nextToken
+            }) >> new ListMetricsResult(metrics: [new Metric(
+                namespace: NAMESPACE, metricName: METRIC_NAME
+
+            )], nextToken: NEXT_TOKEN)
+
+            1 * client.listMetrics({ ListMetricsRequest r ->
+                r.namespace == NAMESPACE && r.nextToken
+            }) >> new ListMetricsResult(metrics: [new Metric(
+                namespace: NAMESPACE, metricName: METRIC_NAME.reverse()
+
+            )])
+
+    }
+
+}

--- a/micronaut-aws-sdk/src/test/groovy/com/agorapulse/micronaut/aws/cloudwatch/CloudWatchServiceSpec.groovy
+++ b/micronaut-aws-sdk/src/test/groovy/com/agorapulse/micronaut/aws/cloudwatch/CloudWatchServiceSpec.groovy
@@ -4,6 +4,7 @@ import com.amazonaws.services.cloudwatch.AmazonCloudWatch
 import com.amazonaws.services.cloudwatch.model.ListMetricsRequest
 import com.amazonaws.services.cloudwatch.model.ListMetricsResult
 import com.amazonaws.services.cloudwatch.model.Metric
+import com.amazonaws.services.cloudwatch.model.PutMetricDataRequest
 import spock.lang.Specification
 
 class CloudWatchServiceSpec extends Specification {
@@ -59,7 +60,9 @@ class CloudWatchServiceSpec extends Specification {
                 }
             }
         then:
-            noExceptionThrown()
+            1 * client.putMetricData({ PutMetricDataRequest request ->
+                request.metricData?.size() == 1
+            })
     }
 
 }

--- a/micronaut-aws-sdk/src/test/groovy/com/agorapulse/micronaut/aws/cloudwatch/CloudWatchServiceSpec.groovy
+++ b/micronaut-aws-sdk/src/test/groovy/com/agorapulse/micronaut/aws/cloudwatch/CloudWatchServiceSpec.groovy
@@ -44,15 +44,19 @@ class CloudWatchServiceSpec extends Specification {
     void 'put metrics'() {
         when:
             service.putMetrics {
-                name METRIC_NAME
+                metric {
+                    name METRIC_NAME
 
-                unit count
+                    unit count
 
-                labels 'DIM_NAME', 'DIM_VALUE'
+                    labels 'DIM_NAME', 'DIM_VALUE'
 
-                data 12, 2
-                data 34, 1
-                data 65, 4
+                    data 12, 2
+                    data 34, 1
+                    data 65, 4
+
+                    values()
+                }
             }
         then:
             noExceptionThrown()


### PR DESCRIPTION
* allows putting metrics and listing existing metrics 


NOTE: there is an extension class which relies on CloudWatch API which breaks the example projects if the library is not present. we need to add wrapper classes around the API classes to break the dependency