### PR TITLE
SNS Refactor : make it more generic and standard compliant

### DIFF
--- a/subprojects/micronaut-amazon-awssdk-sns/src/main/java/com/agorapulse/micronaut/amazon/awssdk/sns/SimpleNotificationService.java
+++ b/subprojects/micronaut-amazon-awssdk-sns/src/main/java/com/agorapulse/micronaut/amazon/awssdk/sns/SimpleNotificationService.java
@@ -31,34 +31,62 @@ import java.util.Map;
  */
 public interface SimpleNotificationService {
 
+    @Deprecated
     String MOBILE_PLATFORM_ANDROID = "android";
+    @Deprecated
     String MOBILE_PLATFORM_IOS = "ios";
+    @Deprecated
     String MOBILE_PLATFORM_IOS_SANDBOX = "iosSandbox";
+    @Deprecated
     String MOBILE_PLATFORM_AMAZON = "amazon";
+    @Deprecated
     String PLATFORM_TYPE_IOS_SANDBOX = "APNS_SANDBOX";
+    @Deprecated
     String PLATFORM_TYPE_IOS = "APNS";
+    @Deprecated
     String PLATFORM_TYPE_ANDROID = "GCM";
+    @Deprecated
     String PLATFORM_TYPE_AMAZON = "ADM";
 
+    enum PlatformType {
+        ADM,
+        APNS,
+        APNS_SANDBOX,
+        GCM
+    }
+
+    /**
+     * @param platformType platform type
+     * @return the default Application ARN for given platform
+     */
+    String getPlatformApplicationArn(PlatformType platformType);
 
     /**
      * @return the default Application ARN for Amazon devices integration.
+     * @deprecated use {@link #getPlatformApplicationArn(PlatformType)}
      */
+    @Deprecated
     String getAmazonApplicationArn();
 
     /**
      * @return the default Application ARN for Android devices integration.
+     * @deprecated use {@link #getPlatformApplicationArn(PlatformType)}
      */
+    @Deprecated
     String getAndroidApplicationArn();
 
     /**
      * @return the default Application ARN for iOS devices integration.
+     * @deprecated use {@link #getPlatformApplicationArn(PlatformType)}
      */
+    @Deprecated
     String getIosApplicationArn();
 
     /**
      * @return the default Application ARN for iOS sandbox devices integration.
+     * @deprecated use {@link #getPlatformApplicationArn(PlatformType)}
      */
+    @Deprecated
     String getIosSandboxApplicationArn();
 
     /**
@@ -209,12 +237,25 @@ public interface SimpleNotificationService {
     /**
      * Creates new platform application.
      * @param name name of the application
+     * @param platformType
+     * @param principal (ADM: clientId - APNS: sslCertificate - GCM: null)
+     * @param credential (ADM: clientSecret - APNS: privateKey - GCM: apiKey)
+     * @return ARN of the platform
+     */
+    String createPlatformApplication(String name, PlatformType platformType, String principal, String credential);
+
+    /**
+     * Creates new platform application.
+     * @param name name of the application
      * @param platformType type of the platform
      * @param principal user's principal
      * @param credential user's credentials
      * @return ARN of the platform
      */
-    String createPlatformApplication(String name, String platformType, String principal, String credential);
+    @Deprecated
+    default String createPlatformApplication(String name, String platformType, String principal, String credential) {
+        return createPlatformApplication(name, PlatformType.valueOf(platformType), principal, credential);
+    }
 
     /**
      * Creates new platform application.
@@ -223,9 +264,11 @@ public interface SimpleNotificationService {
      * @param sslCertificate SSL certificate
      * @param sandbox whether the application should be a iOS sandbox application
      * @return ARN of the platform
+     * @deprecated use {@link #createPlatformApplication(String, PlatformType, String, String)}
      */
+    @Deprecated
     default String createIosApplication(String name, String privateKey, String sslCertificate, boolean sandbox) {
-        return createPlatformApplication(name, sandbox ? PLATFORM_TYPE_IOS_SANDBOX : PLATFORM_TYPE_IOS, sslCertificate, privateKey);
+        return createPlatformApplication(name, sandbox ? PlatformType.APNS_SANDBOX : PlatformType.APNS, sslCertificate, privateKey);
     }
 
     /**
@@ -233,9 +276,11 @@ public interface SimpleNotificationService {
      * @param name name of the application
      * @param apiKey API key
      * @return ARN of the platform
+     * @deprecated use {@link #createPlatformEndpoint(String, String, String) instead}
      */
+    @Deprecated
     default String createAndroidApplication(String name, String apiKey) {
-        return createPlatformApplication(name, PLATFORM_TYPE_ANDROID, null, apiKey);
+        return createPlatformApplication(name, PlatformType.GCM, null, apiKey);
     }
 
     /**
@@ -244,18 +289,44 @@ public interface SimpleNotificationService {
      * @param clientId client ID
      * @param clientSecret client secret
      * @return ARN of the platform
+     * @deprecated use {@link #createPlatformEndpoint(String, String, String) instead}
      */
+    @Deprecated
     default String createAmazonApplication(String name, String clientId, String clientSecret) {
-        return createPlatformApplication(name, PLATFORM_TYPE_AMAZON, clientId, clientSecret);
+        return createPlatformApplication(name, PlatformType.ADM, clientId, clientSecret);
     }
 
     /**
      * Register new device depending on patform
-     * @param platform device platform
+     * @param platformType platform type
      * @param deviceToken device token
      * @param customUserData custom user data
      * @return ARN of the endpoint
+     * @deprecated use {@link PlatformType} instead of platform string
      */
+    default String registerDevice(PlatformType platformType, String deviceToken, String customUserData) {
+        return createPlatformEndpoint(getPlatformApplicationArn(platformType), deviceToken, customUserData);
+    }
+
+    /**
+     * Register new device depending on patform
+     * @param platformType
+     * @param deviceToken device token
+     * @return ARN of the endpoint
+     */
+    default String registerDevice(PlatformType platformType, String deviceToken) {
+        return registerDevice(platformType, deviceToken, "");
+    }
+
+    /**
+     * Register new device depending on patform
+     * @param platform
+     * @param deviceToken device token
+     * @param customUserData custom user data
+     * @return ARN of the endpoint
+     * @deprecated use {@link PlatformType} instead of platform string
+     */
+    @Deprecated
     default String registerDevice(String platform, String deviceToken, String customUserData) {
         if (MOBILE_PLATFORM_ANDROID.equals(platform)) {
             return registerAndroidDevice(deviceToken, customUserData);
@@ -278,6 +349,7 @@ public interface SimpleNotificationService {
      * @param deviceToken device token
      * @return ARN of the endpoint
      */
+    @Deprecated
     default String registerDevice(String platform, String deviceToken) {
         return registerDevice(platform, deviceToken, "");
     }
@@ -286,7 +358,9 @@ public interface SimpleNotificationService {
      * Register new Android device.
      * @param deviceToken device token
      * @return ARN of the endpoint
+     * @deprecated use {@link #registerDevice(PlatformType, String)}
      */
+    @Deprecated
     default String registerAndroidDevice(String deviceToken) {
         return registerAndroidDevice(deviceToken, "");
     }
@@ -296,16 +370,33 @@ public interface SimpleNotificationService {
      * @param deviceToken device token
      * @param customUserData custom user data
      * @return ARN of the endpoint
+     * @deprecated use {@link #registerDevice(PlatformType, String)}
      */
+    @Deprecated
     default String registerAndroidDevice(String deviceToken, String customUserData) {
         return createPlatformEndpoint(getAndroidApplicationArn(), deviceToken, customUserData);
+    }
+
+    /**
+     * Deprecated - If you know the platform applicationArn, use directly createPlatformEndpoint()
+     * Register new Android device.
+     * @param applicationArn application ARN
+     * @param deviceToken device token
+     * @param customUserData custom user data
+     * @return ARN of the endpoint
+     */
+    @Deprecated
+    default String registerAndroidDevice(String applicationArn, String deviceToken, String customUserData) {
+        return createPlatformEndpoint(applicationArn, deviceToken, customUserData);
     }
 
     /**
      * Register new iOS device.
      * @param deviceToken device token
      * @return ARN of the endpoint
+     * @deprecated use {@link #registerDevice(PlatformType, String)}
      */
+    @Deprecated
     default String registerIosDevice(String deviceToken) {
         return registerIosDevice(deviceToken, "");
     }
@@ -315,7 +406,9 @@ public interface SimpleNotificationService {
      * @param deviceToken device token
      * @param customUserData custom user data
      * @return ARN of the endpoint
+     * @deprecated use {@link #registerDevice(PlatformType, String)}
      */
+    @Deprecated
     default String registerIosDevice(String deviceToken, String customUserData) {
         return createPlatformEndpoint(getIosApplicationArn(), deviceToken, customUserData);
     }
@@ -324,7 +417,9 @@ public interface SimpleNotificationService {
      * Register new iOS Sandbox device.
      * @param deviceToken device token
      * @return ARN of the endpoint
+     * @deprecated use {@link #registerDevice(PlatformType, String)}
      */
+    @Deprecated
     default String registerIosSandboxDevice(String deviceToken) {
         return registerIosSandboxDevice(deviceToken, "");
     }
@@ -334,16 +429,33 @@ public interface SimpleNotificationService {
      * @param deviceToken device token
      * @param customUserData custom user data
      * @return ARN of the endpoint
+     * @deprecated use {@link #registerDevice(PlatformType, String)}
      */
+    @Deprecated
     default String registerIosSandboxDevice(String deviceToken, String customUserData) {
         return createPlatformEndpoint(getIosSandboxApplicationArn(), deviceToken, customUserData);
+    }
+
+    /**
+     * Deprecated - If you know the platform applicationArn, use directly createPlatformEndpoint()
+     * Register new device.
+     * @param applicationArn application ARN
+     * @param deviceToken device token
+     * @param customUserData custom user data
+     * @return ARN of the endpoint
+     */
+    @Deprecated
+    default String registerIosDevice(String applicationArn, String deviceToken, String customUserData) {
+        return createPlatformEndpoint(applicationArn, deviceToken, customUserData);
     }
 
     /**
      * Register new Amazon device.
      * @param deviceToken device token
      * @return ARN of the endpoint
+     * @deprecated use {@link #registerDevice(PlatformType, String)}
      */
+    @Deprecated
     default String registerAmazonDevice(String deviceToken) {
         return registerAmazonDevice(deviceToken, "");
     }
@@ -353,9 +465,24 @@ public interface SimpleNotificationService {
      * @param deviceToken device token
      * @param customUserData custom user data
      * @return ARN of the endpoint
+     * @deprecated use {@link #registerDevice(PlatformType, String)}
      */
+    @Deprecated
     default String registerAmazonDevice(String deviceToken, String customUserData) {
-        return createPlatformEndpoint(getAmazonApplicationArn(), deviceToken, customUserData);
+        return registerAmazonDevice(getAmazonApplicationArn(), deviceToken, customUserData);
+    }
+
+    /**
+     * Register new Amazon device.
+     * @param applicationArn application ARN
+     * @param deviceToken device token
+     * @param customUserData custom user data
+     * @return ARN of the endpoint
+     * @deprecated use {@link #createPlatformEndpoint(String, String)}
+     */
+    @Deprecated
+    default String registerAmazonDevice(String applicationArn, String deviceToken, String customUserData) {
+        return createPlatformEndpoint(applicationArn, deviceToken, customUserData);
     }
 
     /**
@@ -386,7 +513,9 @@ public interface SimpleNotificationService {
      * @param timeToLive time to live
      * @param dryRun dry run
      * @return message id
+     * @deprecated use {@link #sendNotification(String, PlatformType, String)}
      */
+    @Deprecated
     String sendAndroidAppNotification(String endpointArn, Map<String, Object> notification, String collapseKey, boolean delayWhileIdle, int timeToLive, boolean dryRun);
 
     /**
@@ -397,7 +526,9 @@ public interface SimpleNotificationService {
      * @param delayWhileIdle delay while idle
      * @param timeToLive time to live
      * @return message id
+     * @deprecated use {@link #sendNotification(String, PlatformType, String)}
      */
+    @Deprecated
     default String sendAndroidAppNotification(String endpointArn, Map<String, Object> notification, String collapseKey, boolean delayWhileIdle, int timeToLive) {
         return sendAndroidAppNotification(endpointArn, notification, collapseKey, delayWhileIdle, timeToLive, false);
     }
@@ -409,7 +540,9 @@ public interface SimpleNotificationService {
      * @param collapseKey collapse key
      * @param delayWhileIdle delay while idle
      * @return message id
+     * @deprecated use {@link #sendNotification(String, PlatformType, String)}
      */
+    @Deprecated
     default String sendAndroidAppNotification(String endpointArn, Map<String, Object> notification, String collapseKey, boolean delayWhileIdle) {
         return sendAndroidAppNotification(endpointArn, notification, collapseKey, delayWhileIdle, 125);
     }
@@ -420,7 +553,9 @@ public interface SimpleNotificationService {
      * @param notification notification payload
      * @param collapseKey collapse key
      * @return message id
+     * @deprecated use {@link #sendNotification(String, PlatformType, String)}
      */
+    @Deprecated
     default String sendAndroidAppNotification(String endpointArn, Map<String, Object> notification, String collapseKey) {
         return sendAndroidAppNotification(endpointArn, notification, collapseKey, true);
     }
@@ -432,7 +567,9 @@ public interface SimpleNotificationService {
      * @param notification notification payload
      * @param sandbox whether the application is a sandbox application
      * @return message id
+     * @deprecated use {@link #sendNotification(String, PlatformType, String)}
      */
+    @Deprecated
     String sendIosAppNotification(String endpointArn, Map<String, Object> notification, boolean sandbox);
 
     /**
@@ -440,10 +577,13 @@ public interface SimpleNotificationService {
      * @param endpointArn endpoint ARN
      * @param notification notification payload
      * @return message id
+     * @deprecated use {@link #sendNotification(String, PlatformType, String)}
      */
+    @Deprecated
     default String sendIosAppNotification(String endpointArn, Map<String, Object> notification) {
         return sendIosAppNotification(endpointArn, notification, false);
     }
+
 
     /**
      * Validates Amazon device.
@@ -454,7 +594,9 @@ public interface SimpleNotificationService {
      * @param deviceToken device token
      * @param customUserData custom user data
      * @return endpoint ARN which can point to different platform if required
+     * @deprecated use {@link #validateDeviceToken(String, String, String, String)}
      */
+    @Deprecated
     default String validateAmazonDevice(String endpointArn, String deviceToken, String customUserData) {
         return validateDeviceToken(getAmazonApplicationArn(), endpointArn, deviceToken, customUserData);
     }
@@ -467,9 +609,28 @@ public interface SimpleNotificationService {
      * @param endpointArn endpoint ARN
      * @param deviceToken device token
      * @return endpoint ARN which can point to different platform if required
+     * @deprecated use {@link #validateDeviceToken(String, String, String, String)}
      */
+    @Deprecated
     default String validateAmazonDevice(String endpointArn, String deviceToken) {
         return validateAmazonDevice(endpointArn, deviceToken, "");
+    }
+
+    /**
+     * Deprecated - use validateDeviceToken()
+     * Validates Android device.
+     *
+     * This method is able to update the custom user data as well as the type of the platform.
+     *
+     * @param applicationArn application ARN
+     * @param endpointArn endpoint ARN
+     * @param deviceToken device token
+     * @param customUserData custom user data
+     * @return endpoint ARN which can point to different platform if required
+     */
+    @Deprecated
+    default String validateAndroidDevice(String applicationArn, String endpointArn, String deviceToken, String customUserData) {
+        return validateDeviceToken(applicationArn, endpointArn, deviceToken, customUserData);
     }
 
     /**
@@ -481,7 +642,9 @@ public interface SimpleNotificationService {
      * @param deviceToken device token
      * @param customUserData custom user data
      * @return endpoint ARN which can point to different platform if required
+     * @deprecated use {@link #validateDeviceToken(String, String, String, String)}
      */
+    @Deprecated
     default String validateAndroidDevice(String endpointArn, String deviceToken, String customUserData) {
         return validateDeviceToken(getAndroidApplicationArn(), endpointArn, deviceToken, customUserData);
     }
@@ -494,9 +657,28 @@ public interface SimpleNotificationService {
      * @param endpointArn endpoint ARN
      * @param deviceToken device token
      * @return endpoint ARN which can point to different platform if required
+     * @deprecated use {@link #validateDeviceToken(String, String, String, String)}
      */
+    @Deprecated
     default String validateAndroidDevice(String endpointArn, String deviceToken) {
         return validateAndroidDevice(endpointArn, deviceToken, "");
+    }
+
+    /**
+     * Deprecated - use validateDeviceToken()
+     * Validates iOS device.
+     *
+     * This method is able to update the custom user data as well as the type of the platform.
+     *
+     * @param applicationArn application ARN
+     * @param endpointArn endpoint ARN
+     * @param deviceToken device token
+     * @param customUserData custom user data
+     * @return endpoint ARN which can point to different platform if required
+     */
+    @Deprecated
+    default String validateIosDevice(String applicationArn, String endpointArn, String deviceToken, String customUserData) {
+        return validateDeviceToken(applicationArn, endpointArn, deviceToken, customUserData);
     }
 
     /**
@@ -508,7 +690,9 @@ public interface SimpleNotificationService {
      * @param deviceToken device token
      * @param customUserData custom user data
      * @return endpoint ARN which can point to different platform if required
+     * @deprecated use {@link #validateDeviceToken(String, String, String, String)}
      */
+    @Deprecated
     default String validateIosDevice(String endpointArn, String deviceToken, String customUserData) {
         return validateDeviceToken(getIosApplicationArn(), endpointArn, deviceToken, customUserData);
     }
@@ -521,7 +705,9 @@ public interface SimpleNotificationService {
      * @param endpointArn endpoint ARN
      * @param deviceToken device token
      * @return endpoint ARN which can point to different platform if required
+     * @deprecated use {@link #validateDeviceToken(String, String, String, String)}
      */
+    @Deprecated
     default String validateIosDevice(String endpointArn, String deviceToken) {
         return validateIosDevice(endpointArn, deviceToken, "");
     }
@@ -535,7 +721,9 @@ public interface SimpleNotificationService {
      * @param deviceToken device token
      * @param customUserData custom user data
      * @return endpoint ARN which can point to different platform if required
+     * @deprecated use {@link #validateDeviceToken(String, String, String, String)}
      */
+    @Deprecated
     default String validateIosSandboxDevice(String endpointArn, String deviceToken, String customUserData) {
         return validateDeviceToken(getIosSandboxApplicationArn(), endpointArn, deviceToken, customUserData);
     }
@@ -548,9 +736,26 @@ public interface SimpleNotificationService {
      * @param endpointArn endpoint ARN
      * @param deviceToken device token
      * @return endpoint ARN which can point to different platform if required
+     * @deprecated use {@link #validateDeviceToken(String, String, String, String)}
      */
+    @Deprecated
     default String validateIosSandboxDevice(String endpointArn, String deviceToken) {
         return validateIosSandboxDevice(endpointArn, deviceToken, "");
+    }
+
+    /**
+     * Validates Platform device.
+     *
+     * This method is able to update the custom user data as well as the type of the platform.
+     *
+     * @param platformType platform type
+     * @param endpointArn endpoint ARN
+     * @param deviceToken device token
+     * @param customUserData custom user data
+     * @return endpoint ARN which can point to different platform if required
+     */
+    default String validateDeviceToken(PlatformType platformType, String endpointArn, String deviceToken, String customUserData) {
+        return validateDeviceToken(getPlatformApplicationArn(platformType), endpointArn, deviceToken, customUserData);
     }
 
     /**
@@ -575,7 +780,9 @@ public interface SimpleNotificationService {
      * @param deviceToken device token
      * @param customUserData custom user data
      * @return endpoint ARN which can point to different platform if required
+     * @deprecated use {@link #validateDeviceToken(String, String, String, String)}
      */
+    @Deprecated
     default String validateDevice(String platform, String endpointArn, String deviceToken, String customUserData) {
         if (MOBILE_PLATFORM_AMAZON.equals(platform)) {
             return validateAmazonDevice(endpointArn, deviceToken, customUserData);
@@ -600,7 +807,9 @@ public interface SimpleNotificationService {
      * @param endpointArn endpoint ARN
      * @param deviceToken device token
      * @return endpoint ARN which can point to different platform if required
+     * @deprecated use {@link #validateDeviceToken(String, String, String, String)}
      */
+    @Deprecated
     default String validateDevice(String platform, String endpointArn, String deviceToken) {
         return validateDevice(platform, endpointArn, deviceToken, "");
     }
@@ -610,6 +819,16 @@ public interface SimpleNotificationService {
      * @param endpointArn endpoint ARN
      */
     void unregisterDevice(String endpointArn);
+
+    /**
+     * Send a push notification to a single mobile target - platform will be included into payload
+     * https://docs.aws.amazon.com/sns/latest/dg/sns-send-custom-platform-specific-payloads-mobile-devices.html
+     * @param endpointArn mobile target's arn
+     * @param platformType identifier of the platform the device is registered in
+     * @param jsonMessage a JSON-formatted message
+     * @return notificationId
+     */
+    String sendNotification(String endpointArn, PlatformType platformType, String jsonMessage);
 
     /**
      * Send SMS
@@ -622,7 +841,7 @@ public interface SimpleNotificationService {
 
     /**
      * Send SMS
-     * @param phoneNumber phone neumber in international format
+     * @param phoneNumber phone number in international format
      * @param message message text
      * @return message ID
      */

--- a/subprojects/micronaut-amazon-awssdk-sns/src/main/java/com/agorapulse/micronaut/amazon/awssdk/sns/SimpleNotificationServiceConfiguration.java
+++ b/subprojects/micronaut-amazon-awssdk-sns/src/main/java/com/agorapulse/micronaut/amazon/awssdk/sns/SimpleNotificationServiceConfiguration.java
@@ -27,33 +27,59 @@ import io.micronaut.context.env.Environment;
 public abstract class SimpleNotificationServiceConfiguration extends DefaultRegionAndEndpointConfiguration {
 
     protected SimpleNotificationServiceConfiguration(String prefix, Environment environment) {
-        ios = forPlatform(prefix, "ios", environment);
-        iosSandbox = forPlatform(prefix, "ios-sandbox", environment);
-        android = forPlatform(prefix, "android", environment);
-        amazon = forPlatform(prefix, "amazon", environment);
+        apns = forPlatform(prefix, "apns", "ios", environment);
+        apnsSandbox = forPlatform(prefix, "apns-sandbox", "ios-sandbox", environment);
+        gcm = forPlatform(prefix, "gcm", "android", environment);
+        adm = forPlatform(prefix, "adm", "amazon", environment);
     }
 
     @SuppressWarnings("DuplicateStringLiteral")
-    private static Application forPlatform(final String prefix, final String platform, final Environment environment) {
-        return new Application(environment.get(prefix + "." + platform + ".arn", String.class).orElseGet(() ->
-            environment.get(prefix + "." + platform + ".applicationArn", String.class).orElse(null)
-       ));
+    private static Application forPlatform(final String prefix, final String platform, final String fallbackPlatform, final Environment environment) {
+        return new Application(
+            environment.get(prefix + "." + platform + ".arn", String.class).orElseGet(() ->
+                environment.get(prefix + "." + platform + ".applicationArn", String.class).orElseGet(() ->
+                    environment.get(prefix + "." + fallbackPlatform + ".arn", String.class).orElseGet(() ->
+                        environment.get(prefix + "." + fallbackPlatform + ".applicationArn", String.class).orElse(null)
+                    )
+                )
+            )
+        );
     }
 
+    @Deprecated
     public final Application getIos() {
-        return ios;
+        return apns;
     }
 
+    @Deprecated
     public final Application getIosSandbox() {
-        return iosSandbox;
+        return apnsSandbox;
     }
 
+    @Deprecated
     public final Application getAndroid() {
-        return android;
+        return gcm;
     }
 
+    @Deprecated
     public final Application getAmazon() {
-        return amazon;
+        return adm;
+    }
+
+    public Application getApns() {
+        return apns;
+    }
+
+    public Application getApnsSandbox() {
+        return apnsSandbox;
+    }
+
+    public Application getGcm() {
+        return gcm;
+    }
+
+    public Application getAdm() {
+        return adm;
     }
 
     public String getTopic() {
@@ -64,10 +90,10 @@ public abstract class SimpleNotificationServiceConfiguration extends DefaultRegi
         this.topic = topic;
     }
 
-    private final Application ios;
-    private final Application iosSandbox;
-    private final Application android;
-    private final Application amazon;
+    private final Application apns;
+    private final Application apnsSandbox;
+    private final Application gcm;
+    private final Application adm;
     private String topic = "";
 
     public static class Application {

--- a/subprojects/micronaut-aws-sdk-sns/src/main/groovy/com/agorapulse/micronaut/aws/sns/DefaultSimpleNotificationService.groovy
+++ b/subprojects/micronaut-aws-sdk-sns/src/main/groovy/com/agorapulse/micronaut/aws/sns/DefaultSimpleNotificationService.groovy
@@ -48,18 +48,18 @@ class DefaultSimpleNotificationService implements SimpleNotificationService {
         this.objectMapper = objectMapper
     }
 
-    String getPushPlatformArn(PLATFORM_TYPE platform) {
-        switch (platform) {
-            case PLATFORM_TYPE.ADM:
+    String getPlatformApplicationArn(PlatformType platformType) {
+        switch (platformType) {
+            case PlatformType.ADM:
                 return checkNotEmpty(configuration.adm.arn, 'Amazon Device Manager application arn must be defined in config')
                 break
-            case PLATFORM_TYPE.APNS:
+            case PlatformType.APNS:
                 return checkNotEmpty(configuration.apns.arn, 'Apple Push Notification service application arn must be defined in config')
                 break
-            case PLATFORM_TYPE.APNS_SANDBOX:
+            case PlatformType.APNS_SANDBOX:
                 return checkNotEmpty(configuration.apnsSandbox.arn, 'Apple Push Notification service Sandbox application arn must be defined in config')
                 break
-            case PLATFORM_TYPE.GCM:
+            case PlatformType.GCM:
                 return checkNotEmpty(configuration.gcm.arn, 'Google Cloud Messaging (Firebase) application arn must be defined in config')
         }
     }
@@ -155,7 +155,7 @@ class DefaultSimpleNotificationService implements SimpleNotificationService {
      * @param jsonMessage a JSON-formatted message
      * @return
      */
-    String sendPushNotification(String endpointArn, PLATFORM_TYPE platformType, String jsonMessage) {
+    String sendPushNotification(String endpointArn, PlatformType platformType, String jsonMessage) {
         publishToTarget(endpointArn, platformType.toString(), jsonMessage)
     }
 
@@ -197,16 +197,16 @@ class DefaultSimpleNotificationService implements SimpleNotificationService {
         deleteEndpoint(endpointArn)
     }
 
-    String createPlatformApplication(String name, PLATFORM_TYPE platform, String principal, String credential) {
-        return createPlatformApplication(name, platform.toString(), principal, credential)
+    String createPlatformApplication(String name, PlatformType platformType, String principal, String credential) {
+        return createPlatformApplication(name, platformType.toString(), principal, credential)
     }
 
     @Deprecated
     @Override
-    String createPlatformApplication(String name, String platformType, String principal, String credential) {
+    String createPlatformApplication(String name, String endpointName, String principal, String credential) {
         CreatePlatformApplicationRequest request = new CreatePlatformApplicationRequest()
             .withName(name)
-            .withPlatform(platformType)
+            .withPlatform(endpointName)
 
         Map<String, String> attributes = [:]
 

--- a/subprojects/micronaut-aws-sdk-sns/src/main/groovy/com/agorapulse/micronaut/aws/sns/DefaultSimpleNotificationService.groovy
+++ b/subprojects/micronaut-aws-sdk-sns/src/main/groovy/com/agorapulse/micronaut/aws/sns/DefaultSimpleNotificationService.groovy
@@ -201,6 +201,7 @@ class DefaultSimpleNotificationService implements SimpleNotificationService {
         return createPlatformApplication(name, platform.toString(), principal, credential)
     }
 
+    @Deprecated
     @Override
     String createPlatformApplication(String name, String platformType, String principal, String credential) {
         CreatePlatformApplicationRequest request = new CreatePlatformApplicationRequest()

--- a/subprojects/micronaut-aws-sdk-sns/src/main/groovy/com/agorapulse/micronaut/aws/sns/DefaultSimpleNotificationService.groovy
+++ b/subprojects/micronaut-aws-sdk-sns/src/main/groovy/com/agorapulse/micronaut/aws/sns/DefaultSimpleNotificationService.groovy
@@ -155,7 +155,7 @@ class DefaultSimpleNotificationService implements SimpleNotificationService {
      * @param jsonMessage a JSON-formatted message
      * @return
      */
-    String sendPushNotification(String endpointArn, PlatformType platformType, String jsonMessage) {
+    String sendNotification(String endpointArn, PlatformType platformType, String jsonMessage) {
         publishToTarget(endpointArn, platformType.toString(), jsonMessage)
     }
 

--- a/subprojects/micronaut-aws-sdk-sns/src/main/groovy/com/agorapulse/micronaut/aws/sns/DefaultSimpleNotificationService.groovy
+++ b/subprojects/micronaut-aws-sdk-sns/src/main/groovy/com/agorapulse/micronaut/aws/sns/DefaultSimpleNotificationService.groovy
@@ -52,13 +52,10 @@ class DefaultSimpleNotificationService implements SimpleNotificationService {
         switch (platformType) {
             case PlatformType.ADM:
                 return checkNotEmpty(configuration.adm.arn, 'Amazon Device Manager application arn must be defined in config')
-                break
             case PlatformType.APNS:
                 return checkNotEmpty(configuration.apns.arn, 'Apple Push Notification service application arn must be defined in config')
-                break
             case PlatformType.APNS_SANDBOX:
                 return checkNotEmpty(configuration.apnsSandbox.arn, 'Apple Push Notification service Sandbox application arn must be defined in config')
-                break
             case PlatformType.GCM:
                 return checkNotEmpty(configuration.gcm.arn, 'Google Cloud Messaging (Firebase) application arn must be defined in config')
         }

--- a/subprojects/micronaut-aws-sdk-sns/src/main/groovy/com/agorapulse/micronaut/aws/sns/SimpleNotificationService.java
+++ b/subprojects/micronaut-aws-sdk-sns/src/main/groovy/com/agorapulse/micronaut/aws/sns/SimpleNotificationService.java
@@ -28,36 +28,65 @@ import java.util.Map;
 /**
  * Service to simplify interaction with Amazon SNS.
  */
+@SuppressWarnings("rawtypes")
 public interface SimpleNotificationService {
 
+    @Deprecated
     String MOBILE_PLATFORM_ANDROID = "android";
+    @Deprecated
     String MOBILE_PLATFORM_IOS = "ios";
+    @Deprecated
     String MOBILE_PLATFORM_IOS_SANDBOX = "iosSandbox";
+    @Deprecated
     String MOBILE_PLATFORM_AMAZON = "amazon";
+    @Deprecated
     String PLATFORM_TYPE_IOS_SANDBOX = "APNS_SANDBOX";
+    @Deprecated
     String PLATFORM_TYPE_IOS = "APNS";
+    @Deprecated
     String PLATFORM_TYPE_ANDROID = "GCM";
+    @Deprecated
     String PLATFORM_TYPE_AMAZON = "ADM";
 
+    enum PLATFORM_TYPE {
+        ADM,
+        APNS,
+        APNS_SANDBOX,
+        GCM
+    }
 
     /**
+     * @param platform: target platform
+     * @return the default Application ARN for given platform
+     */
+    String getPushPlatformArn(PLATFORM_TYPE platform);
+
+    /**
+     * deprecated : use getPushPlatformArn() with matching PUSH_PLATFORM
      * @return the default Application ARN for Amazon devices integration.
      */
+    @Deprecated
     String getAmazonApplicationArn();
 
     /**
+     * deprecated : use getPushPlatformArn() with matching PUSH_PLATFORM
      * @return the default Application ARN for Android devices integration.
      */
+    @Deprecated
     String getAndroidApplicationArn();
 
     /**
+     * deprecated : use getPushPlatformArn() with matching PUSH_PLATFORM
      * @return the default Application ARN for iOS devices integration.
      */
+    @Deprecated
     String getIosApplicationArn();
 
     /**
+     * deprecated : use getPushPlatformArn() with matching PUSH_PLATFORM
      * @return the default Application ARN for iOS sandbox devices integration.
      */
+    @Deprecated
     String getIosSandboxApplicationArn();
 
     /**
@@ -208,11 +237,22 @@ public interface SimpleNotificationService {
     /**
      * Creates new platform application.
      * @param name name of the application
+     * @param platform
+     * @param principal (ADM: clientId - APNS: sslCertificate - GCM: null)
+     * @param credential (ADM: clientSecret - APNS: privateKey - GCM: apiKey)
+     * @return ARN of the platform
+     */
+    String createPlatformApplication(String name, PLATFORM_TYPE platform, String principal, String credential);
+
+    /**
+     * Creates new platform application.
+     * @param name name of the application
      * @param platformType type of the platform
      * @param principal user's principal
      * @param credential user's credentials
      * @return ARN of the platform
      */
+    @Deprecated
     String createPlatformApplication(String name, String platformType, String principal, String credential);
 
     /**
@@ -223,6 +263,7 @@ public interface SimpleNotificationService {
      * @param sandbox whether the application should be a iOS sandbox application
      * @return ARN of the platform
      */
+    @Deprecated
     default String createIosApplication(String name, String privateKey, String sslCertificate, boolean sandbox) {
         return createPlatformApplication(name, sandbox ? PLATFORM_TYPE_IOS_SANDBOX : PLATFORM_TYPE_IOS, sslCertificate, privateKey);
     }
@@ -233,6 +274,7 @@ public interface SimpleNotificationService {
      * @param apiKey API key
      * @return ARN of the platform
      */
+    @Deprecated
     default String createAndroidApplication(String name, String apiKey) {
         return createPlatformApplication(name, PLATFORM_TYPE_ANDROID, null, apiKey);
     }
@@ -244,17 +286,42 @@ public interface SimpleNotificationService {
      * @param clientSecret client secret
      * @return ARN of the platform
      */
+    @Deprecated
     default String createAmazonApplication(String name, String clientId, String clientSecret) {
         return createPlatformApplication(name, PLATFORM_TYPE_AMAZON, clientId, clientSecret);
     }
 
     /**
      * Register new device depending on patform
+     * deprecated: use PUSH_PLATFORM instead of platform string
      * @param platform
      * @param deviceToken device token
      * @param customUserData custom user data
      * @return ARN of the endpoint
      */
+    default String registerDevice(PLATFORM_TYPE platform, String deviceToken, String customUserData) {
+        return createPlatformEndpoint(getPushPlatformArn(platform), deviceToken, customUserData);
+    }
+
+    /**
+     * Register new device depending on patform
+     * @param platform
+     * @param deviceToken device token
+     * @return ARN of the endpoint
+     */
+    default String registerDevice(PLATFORM_TYPE platform, String deviceToken) {
+        return registerDevice(platform, deviceToken, "");
+    }
+
+    /**
+     * Register new device depending on patform
+     * deprecated: use PUSH_PLATFORM instead of platform string
+     * @param platform
+     * @param deviceToken device token
+     * @param customUserData custom user data
+     * @return ARN of the endpoint
+     */
+    @Deprecated
     default String registerDevice(String platform, String deviceToken, String customUserData) {
         if (MOBILE_PLATFORM_ANDROID.equals(platform)) {
             return registerAndroidDevice(deviceToken, customUserData);
@@ -277,6 +344,7 @@ public interface SimpleNotificationService {
      * @param deviceToken device token
      * @return ARN of the endpoint
      */
+    @Deprecated
     default String registerDevice(String platform, String deviceToken) {
         return registerDevice(platform, deviceToken, "");
     }
@@ -286,6 +354,7 @@ public interface SimpleNotificationService {
      * @param deviceToken device token
      * @return ARN of the endpoint
      */
+    @Deprecated
     default String registerAndroidDevice(String deviceToken) {
         return registerAndroidDevice(deviceToken, "");
     }
@@ -296,12 +365,13 @@ public interface SimpleNotificationService {
      * @param customUserData custom user data
      * @return ARN of the endpoint
      */
+    @Deprecated
     default String registerAndroidDevice(String deviceToken, String customUserData) {
         return createPlatformEndpoint(getAndroidApplicationArn(), deviceToken, customUserData);
     }
 
     /**
-     * @Deprecated - If you know the platform applicationArn, use directly createPlatformEndpoint()
+     * Deprecated - If you know the platform applicationArn, use directly createPlatformEndpoint()
      * Register new Android device.
      * @param applicationArn application ARN
      * @param deviceToken device token
@@ -318,6 +388,7 @@ public interface SimpleNotificationService {
      * @param deviceToken device token
      * @return ARN of the endpoint
      */
+    @Deprecated
     default String registerIosDevice(String deviceToken) {
         return registerIosDevice(deviceToken, "");
     }
@@ -328,6 +399,7 @@ public interface SimpleNotificationService {
      * @param customUserData custom user data
      * @return ARN of the endpoint
      */
+    @Deprecated
     default String registerIosDevice(String deviceToken, String customUserData) {
         return createPlatformEndpoint(getIosApplicationArn(), deviceToken, customUserData);
     }
@@ -337,6 +409,7 @@ public interface SimpleNotificationService {
      * @param deviceToken device token
      * @return ARN of the endpoint
      */
+    @Deprecated
     default String registerIosSandboxDevice(String deviceToken) {
         return registerIosDevice(deviceToken, "");
     }
@@ -347,12 +420,13 @@ public interface SimpleNotificationService {
      * @param customUserData custom user data
      * @return ARN of the endpoint
      */
+    @Deprecated
     default String registerIosSandboxDevice(String deviceToken, String customUserData) {
         return createPlatformEndpoint(getIosSandboxApplicationArn(), deviceToken, customUserData);
     }
 
     /**
-     * @Deprecated - If you know the platform applicationArn, use directly createPlatformEndpoint()
+     * Deprecated - If you know the platform applicationArn, use directly createPlatformEndpoint()
      * Register new device.
      * @param applicationArn application ARN
      * @param deviceToken device token
@@ -369,6 +443,7 @@ public interface SimpleNotificationService {
      * @param deviceToken device token
      * @return ARN of the endpoint
      */
+    @Deprecated
     default String registerAmazonDevice(String deviceToken) {
         return registerAmazonDevice(deviceToken, "");
     }
@@ -379,18 +454,20 @@ public interface SimpleNotificationService {
      * @param customUserData custom user data
      * @return ARN of the endpoint
      */
+    @Deprecated
     default String registerAmazonDevice(String deviceToken, String customUserData) {
         return registerAmazonDevice(getAmazonApplicationArn(), deviceToken, customUserData);
     }
 
     /**
-     * @Deprecated - If you know the platform applicationArn, use directly createPlatformEndpoint()
+     * Deprecated - If you know the platform applicationArn, use directly createPlatformEndpoint()
      * Register new Amazon device.
      * @param applicationArn application ARN
      * @param deviceToken device token
      * @param customUserData custom user data
      * @return ARN of the endpoint
      */
+    @Deprecated
     default String registerAmazonDevice(String applicationArn, String deviceToken, String customUserData) {
         return createPlatformEndpoint(applicationArn, deviceToken, customUserData);
     }
@@ -424,6 +501,7 @@ public interface SimpleNotificationService {
      * @param dryRun dry run
      * @return message id
      */
+    @Deprecated
     String sendAndroidAppNotification(String endpointArn, Map notification, String collapseKey, boolean delayWhileIdle, int timeToLive, boolean dryRun);
 
     /**
@@ -435,6 +513,7 @@ public interface SimpleNotificationService {
      * @param timeToLive time to live
      * @return message id
      */
+    @Deprecated
     default String sendAndroidAppNotification(String endpointArn, Map notification, String collapseKey, boolean delayWhileIdle, int timeToLive) {
         return sendAndroidAppNotification(endpointArn, notification, collapseKey, delayWhileIdle, timeToLive, false);
     }
@@ -447,6 +526,7 @@ public interface SimpleNotificationService {
      * @param delayWhileIdle delay while idle
      * @return message id
      */
+    @Deprecated
     default String sendAndroidAppNotification(String endpointArn, Map notification, String collapseKey, boolean delayWhileIdle) {
         return sendAndroidAppNotification(endpointArn, notification, collapseKey, delayWhileIdle, 125);
     }
@@ -458,6 +538,7 @@ public interface SimpleNotificationService {
      * @param collapseKey collapse key
      * @return message id
      */
+    @Deprecated
     default String sendAndroidAppNotification(String endpointArn, Map notification, String collapseKey) {
         return sendAndroidAppNotification(endpointArn, notification, collapseKey, true);
     }
@@ -470,6 +551,7 @@ public interface SimpleNotificationService {
      * @param sandbox whether the application is a sandbox application
      * @return message id
      */
+    @Deprecated
     String sendIosAppNotification(String endpointArn, Map notification, boolean sandbox);
 
     /**
@@ -478,6 +560,7 @@ public interface SimpleNotificationService {
      * @param notification notification payload
      * @return message id
      */
+    @Deprecated
     default String sendIosAppNotification(String endpointArn, Map notification) {
         return sendIosAppNotification(endpointArn, notification, false);
     }
@@ -492,6 +575,7 @@ public interface SimpleNotificationService {
      * @param customUserData custom user data
      * @return endpoint ARN which can point to different platform if required
      */
+    @Deprecated
     default String validateAmazonDevice(String endpointArn, String deviceToken, String customUserData) {
         return validateDeviceToken(getAmazonApplicationArn(), endpointArn, deviceToken, customUserData);
     }
@@ -505,12 +589,13 @@ public interface SimpleNotificationService {
      * @param deviceToken device token
      * @return endpoint ARN which can point to different platform if required
      */
+    @Deprecated
     default String validateAmazonDevice(String endpointArn, String deviceToken) {
         return validateAmazonDevice(endpointArn, deviceToken, "");
     }
 
     /**
-     * @Deprecated - use validateDeviceToken()
+     * Deprecated - use validateDeviceToken()
      * Validates Android device.
      *
      * This method is able to update the custom user data as well as the type of the platform.
@@ -536,6 +621,7 @@ public interface SimpleNotificationService {
      * @param customUserData custom user data
      * @return endpoint ARN which can point to different platform if required
      */
+    @Deprecated
     default String validateAndroidDevice(String endpointArn, String deviceToken, String customUserData) {
         return validateDeviceToken(getAndroidApplicationArn(), endpointArn, deviceToken, customUserData);
     }
@@ -549,12 +635,13 @@ public interface SimpleNotificationService {
      * @param deviceToken device token
      * @return endpoint ARN which can point to different platform if required
      */
+    @Deprecated
     default String validateAndroidDevice(String endpointArn, String deviceToken) {
         return validateAndroidDevice(endpointArn, deviceToken, "");
     }
 
     /**
-     * @Deprecated - use validateDeviceToken()
+     * Deprecated - use validateDeviceToken()
      * Validates iOS device.
      *
      * This method is able to update the custom user data as well as the type of the platform.
@@ -580,6 +667,7 @@ public interface SimpleNotificationService {
      * @param customUserData custom user data
      * @return endpoint ARN which can point to different platform if required
      */
+    @Deprecated
     default String validateIosDevice(String endpointArn, String deviceToken, String customUserData) {
         return validateDeviceToken(getIosApplicationArn(), endpointArn, deviceToken, customUserData);
     }
@@ -593,6 +681,7 @@ public interface SimpleNotificationService {
      * @param deviceToken device token
      * @return endpoint ARN which can point to different platform if required
      */
+    @Deprecated
     default String validateIosDevice(String endpointArn, String deviceToken) {
         return validateIosDevice(endpointArn, deviceToken, "");
     }
@@ -607,6 +696,7 @@ public interface SimpleNotificationService {
      * @param customUserData custom user data
      * @return endpoint ARN which can point to different platform if required
      */
+    @Deprecated
     default String validateIosSandboxDevice(String endpointArn, String deviceToken, String customUserData) {
         return validateDeviceToken(getIosSandboxApplicationArn(), endpointArn, deviceToken, customUserData);
     }
@@ -620,26 +710,24 @@ public interface SimpleNotificationService {
      * @param deviceToken device token
      * @return endpoint ARN which can point to different platform if required
      */
+    @Deprecated
     default String validateIosSandboxDevice(String endpointArn, String deviceToken) {
         return validateIosSandboxDevice(endpointArn, deviceToken, "");
     }
 
     /**
-     * @Deprecated - use validateDeviceToken()
      * Validates Platform device.
      *
      * This method is able to update the custom user data as well as the type of the platform.
      *
-     * @param applicationArn application ARN
-     * @param mobilePlatform type of the mobile platform
+     * @param platform Push platform
      * @param endpointArn endpoint ARN
      * @param deviceToken device token
      * @param customUserData custom user data
      * @return endpoint ARN which can point to different platform if required
      */
-    @Deprecated
-    default String validatePlatformDeviceToken(String applicationArn, String mobilePlatform, String endpointArn, String deviceToken, String customUserData) {
-        return validateDeviceToken(applicationArn, endpointArn, deviceToken, customUserData);
+    default String validatePlatformDeviceToken(PLATFORM_TYPE platform, String endpointArn, String deviceToken, String customUserData) {
+        return validateDeviceToken(getPushPlatformArn(platform), endpointArn, deviceToken, customUserData);
     }
 
     /**
@@ -665,6 +753,7 @@ public interface SimpleNotificationService {
      * @param customUserData custom user data
      * @return endpoint ARN which can point to different platform if required
      */
+    @Deprecated
     default String validateDevice(String platform, String endpointArn, String deviceToken, String customUserData) {
         if (MOBILE_PLATFORM_AMAZON.equals(platform)) {
             return validateAmazonDevice(endpointArn, deviceToken, customUserData);
@@ -690,6 +779,7 @@ public interface SimpleNotificationService {
      * @param deviceToken device token
      * @return endpoint ARN which can point to different platform if required
      */
+    @Deprecated
     default String validateDevice(String platform, String endpointArn, String deviceToken) {
         return validateDevice(platform, endpointArn, deviceToken, "");
     }
@@ -699,6 +789,16 @@ public interface SimpleNotificationService {
      * @param endpointArn endpoint ARN
      */
     void unregisterDevice(String endpointArn);
+
+    /**
+     * Send a push notification to a single mobile target - platform will be included into payload
+     * https://docs.aws.amazon.com/sns/latest/dg/sns-send-custom-platform-specific-payloads-mobile-devices.html
+     * @param endpointArn mobile target's arn
+     * @param platformType identifier of the platform the device is registered in
+     * @param jsonMessage a JSON-formatted message
+     * @return notificationId
+     */
+    String sendPushNotification(String endpointArn, PLATFORM_TYPE platformType, String jsonMessage);
 
     /**
      * Send SMS
@@ -711,7 +811,7 @@ public interface SimpleNotificationService {
 
     /**
      * Send SMS
-     * @param phoneNumber phone neumber in international format
+     * @param phoneNumber phone number in international format
      * @param message message text
      * @return message ID
      */

--- a/subprojects/micronaut-aws-sdk-sns/src/main/groovy/com/agorapulse/micronaut/aws/sns/SimpleNotificationService.java
+++ b/subprojects/micronaut-aws-sdk-sns/src/main/groovy/com/agorapulse/micronaut/aws/sns/SimpleNotificationService.java
@@ -48,7 +48,7 @@ public interface SimpleNotificationService {
     @Deprecated
     String PLATFORM_TYPE_AMAZON = "ADM";
 
-    enum PLATFORM_TYPE {
+    enum PlatformType {
         ADM,
         APNS,
         APNS_SANDBOX,
@@ -56,10 +56,10 @@ public interface SimpleNotificationService {
     }
 
     /**
-     * @param platform: target platform
+     * @param platformType
      * @return the default Application ARN for given platform
      */
-    String getPushPlatformArn(PLATFORM_TYPE platform);
+    String getPlatformApplicationArn(PlatformType platformType);
 
     /**
      * deprecated : use getPushPlatformArn() with matching PUSH_PLATFORM
@@ -237,23 +237,23 @@ public interface SimpleNotificationService {
     /**
      * Creates new platform application.
      * @param name name of the application
-     * @param platform
+     * @param platformType
      * @param principal (ADM: clientId - APNS: sslCertificate - GCM: null)
      * @param credential (ADM: clientSecret - APNS: privateKey - GCM: apiKey)
      * @return ARN of the platform
      */
-    String createPlatformApplication(String name, PLATFORM_TYPE platform, String principal, String credential);
+    String createPlatformApplication(String name, PlatformType platformType, String principal, String credential);
 
     /**
      * Creates new platform application.
      * @param name name of the application
-     * @param platformType type of the platform
+     * @param endpointName type of the platform
      * @param principal user's principal
      * @param credential user's credentials
      * @return ARN of the platform
      */
     @Deprecated
-    String createPlatformApplication(String name, String platformType, String principal, String credential);
+    String createPlatformApplication(String name, String endpointName, String principal, String credential);
 
     /**
      * Creates new platform application.
@@ -294,23 +294,23 @@ public interface SimpleNotificationService {
     /**
      * Register new device depending on patform
      * deprecated: use PUSH_PLATFORM instead of platform string
-     * @param platform
+     * @param platformType
      * @param deviceToken device token
      * @param customUserData custom user data
      * @return ARN of the endpoint
      */
-    default String registerDevice(PLATFORM_TYPE platform, String deviceToken, String customUserData) {
-        return createPlatformEndpoint(getPushPlatformArn(platform), deviceToken, customUserData);
+    default String registerDevice(PlatformType platformType, String deviceToken, String customUserData) {
+        return createPlatformEndpoint(getPlatformApplicationArn(platformType), deviceToken, customUserData);
     }
 
     /**
      * Register new device depending on patform
-     * @param platform
+     * @param platformType
      * @param deviceToken device token
      * @return ARN of the endpoint
      */
-    default String registerDevice(PLATFORM_TYPE platform, String deviceToken) {
-        return registerDevice(platform, deviceToken, "");
+    default String registerDevice(PlatformType platformType, String deviceToken) {
+        return registerDevice(platformType, deviceToken, "");
     }
 
     /**
@@ -726,8 +726,8 @@ public interface SimpleNotificationService {
      * @param customUserData custom user data
      * @return endpoint ARN which can point to different platform if required
      */
-    default String validatePlatformDeviceToken(PLATFORM_TYPE platform, String endpointArn, String deviceToken, String customUserData) {
-        return validateDeviceToken(getPushPlatformArn(platform), endpointArn, deviceToken, customUserData);
+    default String validatePlatformDeviceToken(PlatformType platformType, String endpointArn, String deviceToken, String customUserData) {
+        return validateDeviceToken(getPlatformApplicationArn(platformType), endpointArn, deviceToken, customUserData);
     }
 
     /**
@@ -798,7 +798,7 @@ public interface SimpleNotificationService {
      * @param jsonMessage a JSON-formatted message
      * @return notificationId
      */
-    String sendPushNotification(String endpointArn, PLATFORM_TYPE platformType, String jsonMessage);
+    String sendPushNotification(String endpointArn, PlatformType platformType, String jsonMessage);
 
     /**
      * Send SMS

--- a/subprojects/micronaut-aws-sdk-sns/src/main/groovy/com/agorapulse/micronaut/aws/sns/SimpleNotificationService.java
+++ b/subprojects/micronaut-aws-sdk-sns/src/main/groovy/com/agorapulse/micronaut/aws/sns/SimpleNotificationService.java
@@ -62,28 +62,28 @@ public interface SimpleNotificationService {
     String getPlatformApplicationArn(PlatformType platformType);
 
     /**
-     * deprecated : use getPushPlatformArn() with matching PUSH_PLATFORM
+     * deprecated : use getPlatformApplicationArn() with matching PUSH_PLATFORM
      * @return the default Application ARN for Amazon devices integration.
      */
     @Deprecated
     String getAmazonApplicationArn();
 
     /**
-     * deprecated : use getPushPlatformArn() with matching PUSH_PLATFORM
+     * deprecated : use getPlatformApplicationArn() with matching PUSH_PLATFORM
      * @return the default Application ARN for Android devices integration.
      */
     @Deprecated
     String getAndroidApplicationArn();
 
     /**
-     * deprecated : use getPushPlatformArn() with matching PUSH_PLATFORM
+     * deprecated : use getPlatformApplicationArn() with matching PUSH_PLATFORM
      * @return the default Application ARN for iOS devices integration.
      */
     @Deprecated
     String getIosApplicationArn();
 
     /**
-     * deprecated : use getPushPlatformArn() with matching PUSH_PLATFORM
+     * deprecated : use getPlatformApplicationArn() with matching PUSH_PLATFORM
      * @return the default Application ARN for iOS sandbox devices integration.
      */
     @Deprecated
@@ -247,15 +247,16 @@ public interface SimpleNotificationService {
     /**
      * Creates new platform application.
      * @param name name of the application
-     * @param endpointName type of the platform
+     * @param platformType type of the platform
      * @param principal user's principal
      * @param credential user's credentials
      * @return ARN of the platform
      */
     @Deprecated
-    String createPlatformApplication(String name, String endpointName, String principal, String credential);
+    String createPlatformApplication(String name, String platformType, String principal, String credential);
 
     /**
+     * Deprecated: use createPlatformApplication()
      * Creates new platform application.
      * @param name name of the application
      * @param privateKey private key
@@ -269,6 +270,7 @@ public interface SimpleNotificationService {
     }
 
     /**
+     * Deprecated: use createPlatformApplication()
      * Creates new platform application.
      * @param name name of the application
      * @param apiKey API key
@@ -280,6 +282,7 @@ public interface SimpleNotificationService {
     }
 
     /**
+     * Deprecated: use createPlatformApplication()
      * Creates new platform application.
      * @param name name of the application
      * @param clientId client ID
@@ -350,6 +353,7 @@ public interface SimpleNotificationService {
     }
 
     /**
+     * Deprecated: use registerDevice()
      * Register new Android device.
      * @param deviceToken device token
      * @return ARN of the endpoint
@@ -360,6 +364,7 @@ public interface SimpleNotificationService {
     }
 
     /**
+     * Deprecated: use registerDevice()
      * Register new Android device.
      * @param deviceToken device token
      * @param customUserData custom user data
@@ -384,6 +389,7 @@ public interface SimpleNotificationService {
     }
 
     /**
+     * Deprecated: use registerDevice()
      * Register new iOS device.
      * @param deviceToken device token
      * @return ARN of the endpoint
@@ -394,6 +400,7 @@ public interface SimpleNotificationService {
     }
 
     /**
+     * Deprecated: use registerDevice()
      * Register new iOS device.
      * @param deviceToken device token
      * @param customUserData custom user data
@@ -405,6 +412,7 @@ public interface SimpleNotificationService {
     }
 
     /**
+     * Deprecated: use registerDevice()
      * Register new iOS Sandbox device.
      * @param deviceToken device token
      * @return ARN of the endpoint
@@ -415,6 +423,7 @@ public interface SimpleNotificationService {
     }
 
     /**
+     * Deprecated: use registerDevice()
      * Register new iOS Sandbox device.
      * @param deviceToken device token
      * @param customUserData custom user data
@@ -439,6 +448,7 @@ public interface SimpleNotificationService {
     }
 
     /**
+     * Deprecated: use registerDevice()
      * Register new Amazon device.
      * @param deviceToken device token
      * @return ARN of the endpoint
@@ -449,6 +459,7 @@ public interface SimpleNotificationService {
     }
 
     /**
+     * Deprecated: use registerDevice()
      * Register new Amazon device.
      * @param deviceToken device token
      * @param customUserData custom user data
@@ -492,6 +503,7 @@ public interface SimpleNotificationService {
     }
 
     /**
+     * Deprecated: use sendNotification()
      * Send Android application notification.
      * @param endpointArn endpoint ARN
      * @param notification notification payload
@@ -505,6 +517,7 @@ public interface SimpleNotificationService {
     String sendAndroidAppNotification(String endpointArn, Map notification, String collapseKey, boolean delayWhileIdle, int timeToLive, boolean dryRun);
 
     /**
+     * Deprecated: use sendNotification()
      * Send Android application notification.
      * @param endpointArn endpoint ARN
      * @param notification notification payload
@@ -519,6 +532,7 @@ public interface SimpleNotificationService {
     }
 
     /**
+     * Deprecated: use sendNotification()
      * Send Android application notification.
      * @param endpointArn endpoint ARN
      * @param notification notification payload
@@ -532,6 +546,7 @@ public interface SimpleNotificationService {
     }
 
     /**
+     * Deprecated: use sendNotification()
      * Send Android application notification.
      * @param endpointArn endpoint ARN
      * @param notification notification payload
@@ -545,6 +560,7 @@ public interface SimpleNotificationService {
 
 
     /**
+     * Deprecated: use sendNotification()
      * Send iOS application notification.
      * @param endpointArn endpoint ARN
      * @param notification notification payload
@@ -555,6 +571,7 @@ public interface SimpleNotificationService {
     String sendIosAppNotification(String endpointArn, Map notification, boolean sandbox);
 
     /**
+     * Deprecated: use sendNotification()
      * Send iOS application notification.
      * @param endpointArn endpoint ARN
      * @param notification notification payload
@@ -566,6 +583,7 @@ public interface SimpleNotificationService {
     }
 
     /**
+     * Deprecated: use validateDeviceToken()
      * Validates Amazon device.
      *
      * This method is able to update the custom user data as well as the type of the platform.
@@ -581,6 +599,7 @@ public interface SimpleNotificationService {
     }
 
     /**
+     * Deprecated: use validateDeviceToken()
      * Validates Amazon device.
      *
      * This method is able to update the custom user data as well as the type of the platform.
@@ -612,6 +631,7 @@ public interface SimpleNotificationService {
     }
 
     /**
+     * Deprecated: use validateDeviceToken()
      * Validates Android device.
      *
      * This method is able to update the custom user data as well as the type of the platform.
@@ -627,6 +647,7 @@ public interface SimpleNotificationService {
     }
 
     /**
+     * Deprecated: use validateDeviceToken()
      * Validates Android device.
      *
      * This method is able to update the custom user data as well as the type of the platform.
@@ -658,6 +679,7 @@ public interface SimpleNotificationService {
     }
 
     /**
+     * Deprecated: use validateDeviceToken()
      * Validates iOS device.
      *
      * This method is able to update the custom user data as well as the type of the platform.
@@ -673,6 +695,7 @@ public interface SimpleNotificationService {
     }
 
     /**
+     * Deprecated: use validateDeviceToken()
      * Validates iOS device.
      *
      * This method is able to update the custom user data as well as the type of the platform.
@@ -687,6 +710,7 @@ public interface SimpleNotificationService {
     }
 
     /**
+     * Deprecated: use validateDeviceToken()
      * Validates iOS Sandbox device.
      *
      * This method is able to update the custom user data as well as the type of the platform.
@@ -702,6 +726,7 @@ public interface SimpleNotificationService {
     }
 
     /**
+     * Deprecated: use validateDeviceToken()
      * Validates iOS Sandbox device.
      *
      * This method is able to update the custom user data as well as the type of the platform.
@@ -720,13 +745,13 @@ public interface SimpleNotificationService {
      *
      * This method is able to update the custom user data as well as the type of the platform.
      *
-     * @param platform Push platform
+     * @param platformType platform type
      * @param endpointArn endpoint ARN
      * @param deviceToken device token
      * @param customUserData custom user data
      * @return endpoint ARN which can point to different platform if required
      */
-    default String validatePlatformDeviceToken(PlatformType platformType, String endpointArn, String deviceToken, String customUserData) {
+    default String validateDeviceToken(PlatformType platformType, String endpointArn, String deviceToken, String customUserData) {
         return validateDeviceToken(getPlatformApplicationArn(platformType), endpointArn, deviceToken, customUserData);
     }
 
@@ -744,6 +769,7 @@ public interface SimpleNotificationService {
     String validateDeviceToken(String applicationArn, String endpointArn, String deviceToken, String customUserData);
 
     /**
+     * Deprecated: use validateDeviceToken()
      * Validates device token depending on platform
      *
      * This method is able to update the custom user data as well as the type of the platform.
@@ -771,6 +797,7 @@ public interface SimpleNotificationService {
     }
 
     /**
+     * Deprecated: use validateDeviceToken()
      * Validates device token depending on platform
      *
      * This method is able to update the custom user data as well as the type of the platform.
@@ -798,7 +825,7 @@ public interface SimpleNotificationService {
      * @param jsonMessage a JSON-formatted message
      * @return notificationId
      */
-    String sendPushNotification(String endpointArn, PlatformType platformType, String jsonMessage);
+    String sendNotification(String endpointArn, PlatformType platformType, String jsonMessage);
 
     /**
      * Send SMS

--- a/subprojects/micronaut-aws-sdk-sns/src/main/groovy/com/agorapulse/micronaut/aws/sns/SimpleNotificationService.java
+++ b/subprojects/micronaut-aws-sdk-sns/src/main/groovy/com/agorapulse/micronaut/aws/sns/SimpleNotificationService.java
@@ -56,35 +56,35 @@ public interface SimpleNotificationService {
     }
 
     /**
-     * @param platformType
+     * @param platformType platform type
      * @return the default Application ARN for given platform
      */
     String getPlatformApplicationArn(PlatformType platformType);
 
     /**
-     * deprecated : use getPlatformApplicationArn() with matching PUSH_PLATFORM
      * @return the default Application ARN for Amazon devices integration.
+     * @deprecated use {@link #getPlatformApplicationArn(PlatformType)}
      */
     @Deprecated
     String getAmazonApplicationArn();
 
     /**
-     * deprecated : use getPlatformApplicationArn() with matching PUSH_PLATFORM
      * @return the default Application ARN for Android devices integration.
+     * @deprecated use {@link #getPlatformApplicationArn(PlatformType)}
      */
     @Deprecated
     String getAndroidApplicationArn();
 
     /**
-     * deprecated : use getPlatformApplicationArn() with matching PUSH_PLATFORM
      * @return the default Application ARN for iOS devices integration.
+     * @deprecated use {@link #getPlatformApplicationArn(PlatformType)}
      */
     @Deprecated
     String getIosApplicationArn();
 
     /**
-     * deprecated : use getPlatformApplicationArn() with matching PUSH_PLATFORM
      * @return the default Application ARN for iOS sandbox devices integration.
+     * @deprecated use {@link #getPlatformApplicationArn(PlatformType)}
      */
     @Deprecated
     String getIosSandboxApplicationArn();
@@ -253,54 +253,56 @@ public interface SimpleNotificationService {
      * @return ARN of the platform
      */
     @Deprecated
-    String createPlatformApplication(String name, String platformType, String principal, String credential);
+    default String createPlatformApplication(String name, String platformType, String principal, String credential) {
+        return createPlatformApplication(name, PlatformType.valueOf(platformType), principal, credential);
+    }
 
     /**
-     * Deprecated: use createPlatformApplication()
      * Creates new platform application.
      * @param name name of the application
      * @param privateKey private key
      * @param sslCertificate SSL certificate
      * @param sandbox whether the application should be a iOS sandbox application
      * @return ARN of the platform
+     * @deprecated use {@link #createPlatformApplication(String, PlatformType, String, String)}
      */
     @Deprecated
     default String createIosApplication(String name, String privateKey, String sslCertificate, boolean sandbox) {
-        return createPlatformApplication(name, sandbox ? PLATFORM_TYPE_IOS_SANDBOX : PLATFORM_TYPE_IOS, sslCertificate, privateKey);
+        return createPlatformApplication(name, sandbox ? PlatformType.APNS_SANDBOX : PlatformType.APNS, sslCertificate, privateKey);
     }
 
     /**
-     * Deprecated: use createPlatformApplication()
      * Creates new platform application.
      * @param name name of the application
      * @param apiKey API key
      * @return ARN of the platform
+     * @deprecated use {@link #createPlatformEndpoint(String, String, String) instead}
      */
     @Deprecated
     default String createAndroidApplication(String name, String apiKey) {
-        return createPlatformApplication(name, PLATFORM_TYPE_ANDROID, null, apiKey);
+        return createPlatformApplication(name, PlatformType.GCM, null, apiKey);
     }
 
     /**
-     * Deprecated: use createPlatformApplication()
      * Creates new platform application.
      * @param name name of the application
      * @param clientId client ID
      * @param clientSecret client secret
      * @return ARN of the platform
+     * @deprecated use {@link #createPlatformEndpoint(String, String, String) instead}
      */
     @Deprecated
     default String createAmazonApplication(String name, String clientId, String clientSecret) {
-        return createPlatformApplication(name, PLATFORM_TYPE_AMAZON, clientId, clientSecret);
+        return createPlatformApplication(name, PlatformType.ADM, clientId, clientSecret);
     }
 
     /**
      * Register new device depending on patform
-     * deprecated: use PUSH_PLATFORM instead of platform string
-     * @param platformType
+     * @param platformType platform type
      * @param deviceToken device token
      * @param customUserData custom user data
      * @return ARN of the endpoint
+     * @deprecated use {@link PlatformType} instead of platform string
      */
     default String registerDevice(PlatformType platformType, String deviceToken, String customUserData) {
         return createPlatformEndpoint(getPlatformApplicationArn(platformType), deviceToken, customUserData);
@@ -318,11 +320,11 @@ public interface SimpleNotificationService {
 
     /**
      * Register new device depending on patform
-     * deprecated: use PUSH_PLATFORM instead of platform string
      * @param platform
      * @param deviceToken device token
      * @param customUserData custom user data
      * @return ARN of the endpoint
+     * @deprecated use {@link PlatformType} instead of platform string
      */
     @Deprecated
     default String registerDevice(String platform, String deviceToken, String customUserData) {
@@ -353,10 +355,10 @@ public interface SimpleNotificationService {
     }
 
     /**
-     * Deprecated: use registerDevice()
      * Register new Android device.
      * @param deviceToken device token
      * @return ARN of the endpoint
+     * @deprecated use {@link #registerDevice(PlatformType, String)}
      */
     @Deprecated
     default String registerAndroidDevice(String deviceToken) {
@@ -364,11 +366,11 @@ public interface SimpleNotificationService {
     }
 
     /**
-     * Deprecated: use registerDevice()
      * Register new Android device.
      * @param deviceToken device token
      * @param customUserData custom user data
      * @return ARN of the endpoint
+     * @deprecated use {@link #registerDevice(PlatformType, String)}
      */
     @Deprecated
     default String registerAndroidDevice(String deviceToken, String customUserData) {
@@ -389,10 +391,10 @@ public interface SimpleNotificationService {
     }
 
     /**
-     * Deprecated: use registerDevice()
      * Register new iOS device.
      * @param deviceToken device token
      * @return ARN of the endpoint
+     * @deprecated use {@link #registerDevice(PlatformType, String)}
      */
     @Deprecated
     default String registerIosDevice(String deviceToken) {
@@ -400,11 +402,11 @@ public interface SimpleNotificationService {
     }
 
     /**
-     * Deprecated: use registerDevice()
      * Register new iOS device.
      * @param deviceToken device token
      * @param customUserData custom user data
      * @return ARN of the endpoint
+     * @deprecated use {@link #registerDevice(PlatformType, String)}
      */
     @Deprecated
     default String registerIosDevice(String deviceToken, String customUserData) {
@@ -412,22 +414,22 @@ public interface SimpleNotificationService {
     }
 
     /**
-     * Deprecated: use registerDevice()
      * Register new iOS Sandbox device.
      * @param deviceToken device token
      * @return ARN of the endpoint
+     * @deprecated use {@link #registerDevice(PlatformType, String)}
      */
     @Deprecated
     default String registerIosSandboxDevice(String deviceToken) {
-        return registerIosDevice(deviceToken, "");
+        return registerIosSandboxDevice(deviceToken, "");
     }
 
     /**
-     * Deprecated: use registerDevice()
      * Register new iOS Sandbox device.
      * @param deviceToken device token
      * @param customUserData custom user data
      * @return ARN of the endpoint
+     * @deprecated use {@link #registerDevice(PlatformType, String)}
      */
     @Deprecated
     default String registerIosSandboxDevice(String deviceToken, String customUserData) {
@@ -448,10 +450,10 @@ public interface SimpleNotificationService {
     }
 
     /**
-     * Deprecated: use registerDevice()
      * Register new Amazon device.
      * @param deviceToken device token
      * @return ARN of the endpoint
+     * @deprecated use {@link #registerDevice(PlatformType, String)}
      */
     @Deprecated
     default String registerAmazonDevice(String deviceToken) {
@@ -459,11 +461,11 @@ public interface SimpleNotificationService {
     }
 
     /**
-     * Deprecated: use registerDevice()
      * Register new Amazon device.
      * @param deviceToken device token
      * @param customUserData custom user data
      * @return ARN of the endpoint
+     * @deprecated use {@link #registerDevice(PlatformType, String)}
      */
     @Deprecated
     default String registerAmazonDevice(String deviceToken, String customUserData) {
@@ -471,12 +473,12 @@ public interface SimpleNotificationService {
     }
 
     /**
-     * Deprecated - If you know the platform applicationArn, use directly createPlatformEndpoint()
      * Register new Amazon device.
      * @param applicationArn application ARN
      * @param deviceToken device token
      * @param customUserData custom user data
      * @return ARN of the endpoint
+     * @deprecated use {@link #createPlatformEndpoint(String, String)}
      */
     @Deprecated
     default String registerAmazonDevice(String applicationArn, String deviceToken, String customUserData) {
@@ -503,7 +505,6 @@ public interface SimpleNotificationService {
     }
 
     /**
-     * Deprecated: use sendNotification()
      * Send Android application notification.
      * @param endpointArn endpoint ARN
      * @param notification notification payload
@@ -512,12 +513,12 @@ public interface SimpleNotificationService {
      * @param timeToLive time to live
      * @param dryRun dry run
      * @return message id
+     * @deprecated use {@link #sendNotification(String, PlatformType, String)}
      */
     @Deprecated
-    String sendAndroidAppNotification(String endpointArn, Map notification, String collapseKey, boolean delayWhileIdle, int timeToLive, boolean dryRun);
+    String sendAndroidAppNotification(String endpointArn, Map<String, Object> notification, String collapseKey, boolean delayWhileIdle, int timeToLive, boolean dryRun);
 
     /**
-     * Deprecated: use sendNotification()
      * Send Android application notification.
      * @param endpointArn endpoint ARN
      * @param notification notification payload
@@ -525,65 +526,66 @@ public interface SimpleNotificationService {
      * @param delayWhileIdle delay while idle
      * @param timeToLive time to live
      * @return message id
+     * @deprecated use {@link #sendNotification(String, PlatformType, String)}
      */
     @Deprecated
-    default String sendAndroidAppNotification(String endpointArn, Map notification, String collapseKey, boolean delayWhileIdle, int timeToLive) {
+    default String sendAndroidAppNotification(String endpointArn, Map<String, Object> notification, String collapseKey, boolean delayWhileIdle, int timeToLive) {
         return sendAndroidAppNotification(endpointArn, notification, collapseKey, delayWhileIdle, timeToLive, false);
     }
 
     /**
-     * Deprecated: use sendNotification()
      * Send Android application notification.
      * @param endpointArn endpoint ARN
      * @param notification notification payload
      * @param collapseKey collapse key
      * @param delayWhileIdle delay while idle
      * @return message id
+     * @deprecated use {@link #sendNotification(String, PlatformType, String)}
      */
     @Deprecated
-    default String sendAndroidAppNotification(String endpointArn, Map notification, String collapseKey, boolean delayWhileIdle) {
+    default String sendAndroidAppNotification(String endpointArn, Map<String, Object> notification, String collapseKey, boolean delayWhileIdle) {
         return sendAndroidAppNotification(endpointArn, notification, collapseKey, delayWhileIdle, 125);
     }
 
     /**
-     * Deprecated: use sendNotification()
      * Send Android application notification.
      * @param endpointArn endpoint ARN
      * @param notification notification payload
      * @param collapseKey collapse key
      * @return message id
+     * @deprecated use {@link #sendNotification(String, PlatformType, String)}
      */
     @Deprecated
-    default String sendAndroidAppNotification(String endpointArn, Map notification, String collapseKey) {
+    default String sendAndroidAppNotification(String endpointArn, Map<String, Object> notification, String collapseKey) {
         return sendAndroidAppNotification(endpointArn, notification, collapseKey, true);
     }
 
 
     /**
-     * Deprecated: use sendNotification()
      * Send iOS application notification.
      * @param endpointArn endpoint ARN
      * @param notification notification payload
      * @param sandbox whether the application is a sandbox application
      * @return message id
+     * @deprecated use {@link #sendNotification(String, PlatformType, String)}
      */
     @Deprecated
-    String sendIosAppNotification(String endpointArn, Map notification, boolean sandbox);
+    String sendIosAppNotification(String endpointArn, Map<String, Object> notification, boolean sandbox);
 
     /**
-     * Deprecated: use sendNotification()
      * Send iOS application notification.
      * @param endpointArn endpoint ARN
      * @param notification notification payload
      * @return message id
+     * @deprecated use {@link #sendNotification(String, PlatformType, String)}
      */
     @Deprecated
-    default String sendIosAppNotification(String endpointArn, Map notification) {
+    default String sendIosAppNotification(String endpointArn, Map<String, Object> notification) {
         return sendIosAppNotification(endpointArn, notification, false);
     }
 
+
     /**
-     * Deprecated: use validateDeviceToken()
      * Validates Amazon device.
      *
      * This method is able to update the custom user data as well as the type of the platform.
@@ -592,6 +594,7 @@ public interface SimpleNotificationService {
      * @param deviceToken device token
      * @param customUserData custom user data
      * @return endpoint ARN which can point to different platform if required
+     * @deprecated use {@link #validateDeviceToken(String, String, String, String)}
      */
     @Deprecated
     default String validateAmazonDevice(String endpointArn, String deviceToken, String customUserData) {
@@ -599,7 +602,6 @@ public interface SimpleNotificationService {
     }
 
     /**
-     * Deprecated: use validateDeviceToken()
      * Validates Amazon device.
      *
      * This method is able to update the custom user data as well as the type of the platform.
@@ -607,6 +609,7 @@ public interface SimpleNotificationService {
      * @param endpointArn endpoint ARN
      * @param deviceToken device token
      * @return endpoint ARN which can point to different platform if required
+     * @deprecated use {@link #validateDeviceToken(String, String, String, String)}
      */
     @Deprecated
     default String validateAmazonDevice(String endpointArn, String deviceToken) {
@@ -631,7 +634,6 @@ public interface SimpleNotificationService {
     }
 
     /**
-     * Deprecated: use validateDeviceToken()
      * Validates Android device.
      *
      * This method is able to update the custom user data as well as the type of the platform.
@@ -640,6 +642,7 @@ public interface SimpleNotificationService {
      * @param deviceToken device token
      * @param customUserData custom user data
      * @return endpoint ARN which can point to different platform if required
+     * @deprecated use {@link #validateDeviceToken(String, String, String, String)}
      */
     @Deprecated
     default String validateAndroidDevice(String endpointArn, String deviceToken, String customUserData) {
@@ -647,7 +650,6 @@ public interface SimpleNotificationService {
     }
 
     /**
-     * Deprecated: use validateDeviceToken()
      * Validates Android device.
      *
      * This method is able to update the custom user data as well as the type of the platform.
@@ -655,6 +657,7 @@ public interface SimpleNotificationService {
      * @param endpointArn endpoint ARN
      * @param deviceToken device token
      * @return endpoint ARN which can point to different platform if required
+     * @deprecated use {@link #validateDeviceToken(String, String, String, String)}
      */
     @Deprecated
     default String validateAndroidDevice(String endpointArn, String deviceToken) {
@@ -679,7 +682,6 @@ public interface SimpleNotificationService {
     }
 
     /**
-     * Deprecated: use validateDeviceToken()
      * Validates iOS device.
      *
      * This method is able to update the custom user data as well as the type of the platform.
@@ -688,6 +690,7 @@ public interface SimpleNotificationService {
      * @param deviceToken device token
      * @param customUserData custom user data
      * @return endpoint ARN which can point to different platform if required
+     * @deprecated use {@link #validateDeviceToken(String, String, String, String)}
      */
     @Deprecated
     default String validateIosDevice(String endpointArn, String deviceToken, String customUserData) {
@@ -695,7 +698,6 @@ public interface SimpleNotificationService {
     }
 
     /**
-     * Deprecated: use validateDeviceToken()
      * Validates iOS device.
      *
      * This method is able to update the custom user data as well as the type of the platform.
@@ -703,6 +705,7 @@ public interface SimpleNotificationService {
      * @param endpointArn endpoint ARN
      * @param deviceToken device token
      * @return endpoint ARN which can point to different platform if required
+     * @deprecated use {@link #validateDeviceToken(String, String, String, String)}
      */
     @Deprecated
     default String validateIosDevice(String endpointArn, String deviceToken) {
@@ -710,7 +713,6 @@ public interface SimpleNotificationService {
     }
 
     /**
-     * Deprecated: use validateDeviceToken()
      * Validates iOS Sandbox device.
      *
      * This method is able to update the custom user data as well as the type of the platform.
@@ -719,6 +721,7 @@ public interface SimpleNotificationService {
      * @param deviceToken device token
      * @param customUserData custom user data
      * @return endpoint ARN which can point to different platform if required
+     * @deprecated use {@link #validateDeviceToken(String, String, String, String)}
      */
     @Deprecated
     default String validateIosSandboxDevice(String endpointArn, String deviceToken, String customUserData) {
@@ -726,7 +729,6 @@ public interface SimpleNotificationService {
     }
 
     /**
-     * Deprecated: use validateDeviceToken()
      * Validates iOS Sandbox device.
      *
      * This method is able to update the custom user data as well as the type of the platform.
@@ -734,6 +736,7 @@ public interface SimpleNotificationService {
      * @param endpointArn endpoint ARN
      * @param deviceToken device token
      * @return endpoint ARN which can point to different platform if required
+     * @deprecated use {@link #validateDeviceToken(String, String, String, String)}
      */
     @Deprecated
     default String validateIosSandboxDevice(String endpointArn, String deviceToken) {
@@ -769,7 +772,6 @@ public interface SimpleNotificationService {
     String validateDeviceToken(String applicationArn, String endpointArn, String deviceToken, String customUserData);
 
     /**
-     * Deprecated: use validateDeviceToken()
      * Validates device token depending on platform
      *
      * This method is able to update the custom user data as well as the type of the platform.
@@ -778,6 +780,7 @@ public interface SimpleNotificationService {
      * @param deviceToken device token
      * @param customUserData custom user data
      * @return endpoint ARN which can point to different platform if required
+     * @deprecated use {@link #validateDeviceToken(String, String, String, String)}
      */
     @Deprecated
     default String validateDevice(String platform, String endpointArn, String deviceToken, String customUserData) {
@@ -797,7 +800,6 @@ public interface SimpleNotificationService {
     }
 
     /**
-     * Deprecated: use validateDeviceToken()
      * Validates device token depending on platform
      *
      * This method is able to update the custom user data as well as the type of the platform.
@@ -805,6 +807,7 @@ public interface SimpleNotificationService {
      * @param endpointArn endpoint ARN
      * @param deviceToken device token
      * @return endpoint ARN which can point to different platform if required
+     * @deprecated use {@link #validateDeviceToken(String, String, String, String)}
      */
     @Deprecated
     default String validateDevice(String platform, String endpointArn, String deviceToken) {

--- a/subprojects/micronaut-aws-sdk-sns/src/main/groovy/com/agorapulse/micronaut/aws/sns/SimpleNotificationServiceConfiguration.groovy
+++ b/subprojects/micronaut-aws-sdk-sns/src/main/groovy/com/agorapulse/micronaut/aws/sns/SimpleNotificationServiceConfiguration.groovy
@@ -46,34 +46,36 @@ abstract class SimpleNotificationServiceConfiguration extends DefaultRegionAndEn
     final Application gcm
 
     @Deprecated
-    final Application ios
+    Application getIos() { return apns }
+
     @Deprecated
-    final Application iosSandbox
+    Application getIosSandbox() { return apnsSandbox }
+
     @Deprecated
-    final Application android
+    Application getAndroid() { return gcm }
+
     @Deprecated
-    final Application amazon
+    Application getAmazon() { return adm }
 
     String topic = ''
 
     protected SimpleNotificationServiceConfiguration(String prefix, Environment environment) {
         this.environment = environment
-        adm = forPlatform(prefix, 'adm', environment)
-        apns = forPlatform(prefix, 'apns', environment)
-        apnsSandbox = forPlatform(prefix, 'apnsSandbox', environment)
-        gcm = forPlatform(prefix, 'gcm', environment)
-
-        ios = forPlatform(prefix, 'ios', environment)
-        iosSandbox = forPlatform(prefix, 'iosSandbox', environment)
-        android = forPlatform(prefix, 'android', environment)
-        amazon = forPlatform(prefix, 'amazon', environment)
+        adm = forPlatform(prefix, 'adm', 'amazon', environment)
+        apns = forPlatform(prefix, 'apns', 'ios', environment)
+        apnsSandbox = forPlatform(prefix, 'apnsSandbox', 'iosSandbox', environment)
+        gcm = forPlatform(prefix, 'gcm', 'android', environment)
     }
 
     @SuppressWarnings('DuplicateStringLiteral')
-    private static Application forPlatform(String prefix, String platform, Environment environment) {
+    private static Application forPlatform(String prefix, String platform, String fallbackPlatform, Environment environment) {
         return new Application(
             environment.get(prefix + '.' + platform + '.arn', String).orElseGet {
-                environment.get(prefix + '.' + platform + '.applicationArn', String).orElse(null)
+                environment.get(prefix + '.' + platform + '.applicationArn', String).orElseGet {
+                    environment.get(prefix + '.' + fallbackPlatform + '.arn', String).orElseGet {
+                        environment.get(prefix + '.' + fallbackPlatform + '.applicationArn', String).orElse(null)
+                    }
+                }
             })
     }
 

--- a/subprojects/micronaut-aws-sdk-sns/src/main/groovy/com/agorapulse/micronaut/aws/sns/SimpleNotificationServiceConfiguration.groovy
+++ b/subprojects/micronaut-aws-sdk-sns/src/main/groovy/com/agorapulse/micronaut/aws/sns/SimpleNotificationServiceConfiguration.groovy
@@ -40,15 +40,29 @@ abstract class SimpleNotificationServiceConfiguration extends DefaultRegionAndEn
 
     private final Environment environment
 
+    final Application adm
+    final Application apns
+    final Application apnsSandbox
+    final Application gcm
+
+    @Deprecated
     final Application ios
+    @Deprecated
     final Application iosSandbox
+    @Deprecated
     final Application android
+    @Deprecated
     final Application amazon
 
     String topic = ''
 
     protected SimpleNotificationServiceConfiguration(String prefix, Environment environment) {
         this.environment = environment
+        adm = forPlatform(prefix, 'adm', environment)
+        apns = forPlatform(prefix, 'apns', environment)
+        apnsSandbox = forPlatform(prefix, 'apnsSandbox', environment)
+        gcm = forPlatform(prefix, 'gcm', environment)
+
         ios = forPlatform(prefix, 'ios', environment)
         iosSandbox = forPlatform(prefix, 'iosSandbox', environment)
         android = forPlatform(prefix, 'android', environment)

--- a/subprojects/micronaut-aws-sdk-sns/src/test/groovy/com/agorapulse/micronaut/aws/sns/SimpleNotificationServiceTest.java
+++ b/subprojects/micronaut-aws-sdk-sns/src/test/groovy/com/agorapulse/micronaut/aws/sns/SimpleNotificationServiceTest.java
@@ -125,18 +125,15 @@ public class SimpleNotificationServiceTest {
     @Test
     public void testPlatformApplications() {
         // tag::applications[]
-        String appArn = service.createAndroidApplication("my-app", API_KEY);        // <1>
+        String appArn = service.createPlatformApplication("my-app", SimpleNotificationService.PlatformType.GCM, null, API_KEY);        // <1>
 
-        String endpoint = service.registerAndroidDevice(appArn, DEVICE_TOKEN, DATA);    // <2>
+        String endpoint = service.registerDevice(SimpleNotificationService.PlatformType.GCM, DEVICE_TOKEN, DATA);    // <2>
 
-        Map<String, String> notif = new LinkedHashMap<>();
-        notif.put("badge", "9");
-        notif.put("data", "{\"foo\": \"some bar\"}");
-        notif.put("title", "Some Title");
+        String jsonMessage = "{\"data\", \"{\"foo\": \"some bar\"}\", \"notification\", \"{\"title\": \"some title\", \"body\": \"some body\"}\"}";
 
-        String msgId = service.sendAndroidAppNotification(endpoint, notif, "Welcome");  // <3>
+        String msgId = service.sendNotification(endpoint, SimpleNotificationService.PlatformType.GCM, jsonMessage);  // <3>
 
-        service.validateAndroidDevice(appArn, endpoint, DEVICE_TOKEN, DATA);            // <4>
+        service.validateDeviceToken(appArn, endpoint, DEVICE_TOKEN, DATA); // <4>
 
         service.unregisterDevice(endpoint);                                             // <5>
         // end::applications[]

--- a/subprojects/micronaut-aws-sdk-sns/src/test/groovy/com/agorapulse/micronaut/aws/sns/SimpleNotificationServiceTest.java
+++ b/subprojects/micronaut-aws-sdk-sns/src/test/groovy/com/agorapulse/micronaut/aws/sns/SimpleNotificationServiceTest.java
@@ -127,7 +127,7 @@ public class SimpleNotificationServiceTest {
         // tag::applications[]
         String appArn = service.createPlatformApplication("my-app", SimpleNotificationService.PlatformType.GCM, null, API_KEY);        // <1>
 
-        String endpoint = service.registerDevice(SimpleNotificationService.PlatformType.GCM, DEVICE_TOKEN, DATA);    // <2>
+        String endpoint = service.createPlatformEndpoint(appArn, DEVICE_TOKEN, DATA);    // <2>
 
         String jsonMessage = "{\"data\", \"{\"foo\": \"some bar\"}\", \"notification\", \"{\"title\": \"some title\", \"body\": \"some body\"}\"}";
 

--- a/subprojects/micronaut-aws-sdk-sns/src/test/groovy/com/agorapulse/micronaut/aws/sns/SimpleNotificationServiceTest.java
+++ b/subprojects/micronaut-aws-sdk-sns/src/test/groovy/com/agorapulse/micronaut/aws/sns/SimpleNotificationServiceTest.java
@@ -29,7 +29,6 @@ import org.testcontainers.containers.localstack.LocalStackContainer;
 
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
- name platforms by application name instead of device name (in some cases you might be able to publish ios message via Firebase for example)
- use generic functions for all platforms using PlatformType (I kept "platform" wording to match AWS documentation)
- let user create message on his own - for example, the way we create android message is not standard