### PR TITLE
[Ch48889] support for java.time.Instant in DynamoDBService methods added

### DIFF
--- a/subprojects/micronaut-aws-sdk-dynamodb/src/main/groovy/com/agorapulse/micronaut/aws/dynamodb/DefaultDynamoDBService.groovy
+++ b/subprojects/micronaut-aws-sdk-dynamodb/src/main/groovy/com/agorapulse/micronaut/aws/dynamodb/DefaultDynamoDBService.groovy
@@ -680,6 +680,9 @@ class DefaultDynamoDBService<TItemClass> implements DynamoDBService<TItemClass> 
         if (key instanceof Date) {
             return new AttributeValue().withS(serializeDate(key))
         }
+        if (key instanceof Instant) {
+            return new AttributeValue().withS(serializeDate(key))
+        }
         return new AttributeValue().withS(key.toString())
     }
 

--- a/subprojects/micronaut-aws-sdk-dynamodb/src/main/groovy/com/agorapulse/micronaut/aws/dynamodb/DefaultDynamoDBService.groovy
+++ b/subprojects/micronaut-aws-sdk-dynamodb/src/main/groovy/com/agorapulse/micronaut/aws/dynamodb/DefaultDynamoDBService.groovy
@@ -27,6 +27,8 @@ import io.micronaut.core.naming.NameUtils
 
 import java.lang.reflect.Method
 import java.text.SimpleDateFormat
+import java.time.Instant
+import java.time.format.DateTimeFormatter
 
 /**
  * Default implementation of DynamoDB service.
@@ -60,6 +62,12 @@ class DefaultDynamoDBService<TItemClass> implements DynamoDBService<TItemClass> 
         SimpleDateFormat dateFormatter = new SimpleDateFormat(SERIALIZED_DATE_FORMAT, Locale.ENGLISH)
         dateFormatter.timeZone = TimeZone.getTimeZone(SERIALIZED_DATE_TIMEZONE)
         return dateFormatter.format(date)
+    }
+
+    static String serializeDate(Instant instant) {
+        return DateTimeFormatter.ofPattern(SERIALIZED_DATE_FORMAT)
+            .withZone(TimeZone.getTimeZone(SERIALIZED_DATE_TIMEZONE).toZoneId())
+            .format(instant)
     }
 
     @CompileDynamic

--- a/subprojects/micronaut-aws-sdk-dynamodb/src/main/groovy/com/agorapulse/micronaut/aws/dynamodb/DynamoDBService.java
+++ b/subprojects/micronaut-aws-sdk-dynamodb/src/main/groovy/com/agorapulse/micronaut/aws/dynamodb/DynamoDBService.java
@@ -22,6 +22,7 @@ import com.amazonaws.services.dynamodbv2.datamodeling.PaginatedQueryList;
 import com.amazonaws.services.dynamodbv2.datamodeling.QueryResultPage;
 import com.amazonaws.services.dynamodbv2.model.*;
 
+import java.time.Instant;
 import java.util.*;
 
 /**
@@ -106,6 +107,10 @@ public interface DynamoDBService<T> {
         return count(hashKey, null);
     }
 
+    /**
+     * @deprecated Consider using the method with java.time.Instant parameter {@code DynamoDBService.countByDates(Object hashKey, String rangeKeyName, Instant after, Instant before, Instant maxAfterDate)}
+     */
+    @Deprecated
     default int countByDates(Object hashKey, String rangeKeyName, Date after, Date before, Date maxAfterDate) {
         Map<String, Object> rangeKeyDates = new HashMap<>(2);
         rangeKeyDates.put("after", after);
@@ -113,7 +118,22 @@ public interface DynamoDBService<T> {
         return countByDates(hashKey, rangeKeyName, rangeKeyDates, Collections.singletonMap("maxAfterDate", maxAfterDate));
     }
 
+    /**
+     * @deprecated Consider using the method with java.time.Instant parameter {@code DynamoDBService.countByDates(Object hashKey, String rangeKeyName, Instant after, Instant before)}
+     */
+    @Deprecated
     default int countByDates(Object hashKey, String rangeKeyName, Date after, Date before) {
+        return countByDates(hashKey, rangeKeyName, after, before, null);
+    }
+
+    default int countByDates(Object hashKey, String rangeKeyName, Instant after, Instant before, Instant maxAfterDate) {
+        Map<String, Object> rangeKeyDates = new HashMap<>(2);
+        rangeKeyDates.put("after", after);
+        rangeKeyDates.put("before", before);
+        return countByDates(hashKey, rangeKeyName, rangeKeyDates, Collections.singletonMap("maxAfterDate", maxAfterDate));
+    }
+
+    default int countByDates(Object hashKey, String rangeKeyName, Instant after, Instant before) {
         return countByDates(hashKey, rangeKeyName, after, before, null);
     }
 
@@ -649,11 +669,30 @@ public interface DynamoDBService<T> {
         return queryByDates(hashKey, rangeKeyName, rangeKeyDates, Collections.emptyMap());
     }
 
+    /**
+     * @deprecated Consider using the method with java.time.Instant parameter {@code DynamoDBService.queryByDates(Object hashKey, String rangeKeyName, Instant after, Instant before)}
+     */
+    @Deprecated
     default QueryResultPage<T> queryByDates(Object hashKey, String rangeKeyName, Date after, Date before) {
         return queryByDates(hashKey, rangeKeyName, after, before, null);
     }
 
+    /**
+     * @deprecated Consider using the method with java.time.Instant parameter {@code DynamoDBService.queryByDates(Object hashKey, String rangeKeyName, Instant after, Instant before, Instant maxAfterDate)}
+     */
+    @Deprecated
     default QueryResultPage<T> queryByDates(Object hashKey, String rangeKeyName, Date after, Date before, Date maxAfterDate) {
+        Map<String, Object> rangeKeyDates = new HashMap<>(2);
+        rangeKeyDates.put("after", after);
+        rangeKeyDates.put("before", before);
+        return queryByDates(hashKey, rangeKeyName, rangeKeyDates, Collections.singletonMap("maxAfterDate", maxAfterDate));
+    }
+
+    default QueryResultPage<T> queryByDates(Object hashKey, String rangeKeyName, Instant after, Instant before) {
+        return queryByDates(hashKey, rangeKeyName, after, before, null);
+    }
+
+    default QueryResultPage<T> queryByDates(Object hashKey, String rangeKeyName, Instant after, Instant before, Instant maxAfterDate) {
         Map<String, Object> rangeKeyDates = new HashMap<>(2);
         rangeKeyDates.put("after", after);
         rangeKeyDates.put("before", before);

--- a/subprojects/micronaut-aws-sdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/aws/dynamodb/DynamoDBServiceTest.java
+++ b/subprojects/micronaut-aws-sdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/aws/dynamodb/DynamoDBServiceTest.java
@@ -30,6 +30,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Date;
 
@@ -40,6 +42,7 @@ public class DynamoDBServiceTest {
 // end::header[]
 
     private static final DateTime REFERENCE_DATE = new DateTime(1358487600000L);
+    private static final Instant REFERENCE_INSTANT = Instant.ofEpochMilli(1358487600000L);
 
     // tag::setup[]
     @Rule
@@ -129,6 +132,8 @@ public class DynamoDBServiceTest {
         );
         assertEquals(1, s.countByDates("3", DynamoDBEntity.DATE_INDEX, REFERENCE_DATE.plusDays(9).toDate(), REFERENCE_DATE.plusDays(20).toDate()));
 
+        assertEquals(1, s.countByDates("3", DynamoDBEntity.DATE_INDEX, REFERENCE_INSTANT.plus(9, ChronoUnit.DAYS), REFERENCE_INSTANT.plus(20, ChronoUnit.DAYS)));
+
         assertNotNull(
             s.query("1")
         );
@@ -141,9 +146,15 @@ public class DynamoDBServiceTest {
         // end::query-by-range-index[]
         assertEquals("bar", s.query("1", DynamoDBEntity.RANGE_INDEX, "bar").getResults().get(0).rangeIndex);
 
-        assertEquals(2,
+        assertEquals(
+            2,
+            s.queryByDates("1", DynamoDBEntity.DATE_INDEX, REFERENCE_DATE.minusDays(1).toDate(), REFERENCE_DATE.plusDays(2).toDate()).getCount().intValue()
+        );
 
-        s.queryByDates("1", DynamoDBEntity.DATE_INDEX, REFERENCE_DATE.minusDays(1).toDate(), REFERENCE_DATE.plusDays(2).toDate()).getCount().intValue());
+        assertEquals(
+            2,
+            s.queryByDates("1", DynamoDBEntity.DATE_INDEX, REFERENCE_INSTANT.minus(1, ChronoUnit.DAYS), REFERENCE_INSTANT.plus(2, ChronoUnit.DAYS)).getCount().intValue()
+        );
 
         //CHECKSTYLE:OFF
         // tag::query-by-dates[]


### PR DESCRIPTION
This pull request adds the following method variants to the `DynamoDBService`:

* `countByDates(Object hashKey, String rangeKeyName, Instant after, Instant before, Instant maxAfterDate)`
* `countByDates(Object hashKey, String rangeKeyName, Instant after, Instant before)`
* `queryByDates(Object hashKey, String rangeKeyName, Instant after, Instant before, Instant maxAfterDate)`
* `queryByDates(Object hashKey, String rangeKeyName, Instant after, Instant before)`