### PR TITLE
prevent hyphening keys in the localstack.env.* configuration map

### DIFF
--- a/subprojects/micronaut-amazon-awssdk-integration-testing/src/main/java/com/agorapulse/micronaut/amazon/awssdk/itest/localstack/AbstractContainerConfiguration.java
+++ b/subprojects/micronaut-amazon-awssdk-integration-testing/src/main/java/com/agorapulse/micronaut/amazon/awssdk/itest/localstack/AbstractContainerConfiguration.java
@@ -17,6 +17,9 @@
  */
 package com.agorapulse.micronaut.amazon.awssdk.itest.localstack;
 
+import io.micronaut.core.convert.format.MapFormat;
+import io.micronaut.core.naming.conventions.StringConvention;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -55,7 +58,7 @@ public abstract class AbstractContainerConfiguration {
         return env;
     }
 
-    public void setEnv(Map<String, String> env) {
+    public void setEnv(@MapFormat(keyFormat = StringConvention.RAW) Map<String, String> env) {
         this.env = env;
     }
 }

--- a/subprojects/micronaut-amazon-awssdk-integration-testing/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/itest/localstack/LocalstackContainerConfigurationSpec.groovy
+++ b/subprojects/micronaut-amazon-awssdk-integration-testing/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/itest/localstack/LocalstackContainerConfigurationSpec.groovy
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2018-2023 Agorapulse.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.agorapulse.micronaut.amazon.awssdk.itest.localstack
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.test.annotation.MicronautTest
+import spock.lang.Specification
+
+import javax.inject.Inject
+
+@MicronautTest
+@Property(name = 'localstack.env.DEBUG', value = '1')
+@Property(name = 'localstack.env.LAMBDA_EXECUTOR', value = 'local')
+class LocalstackContainerConfigurationSpec extends Specification {
+
+    @Inject LocalstackContainerConfiguration configuration
+
+    void 'env map should not apply hyphenated conversion to the key values'() {
+        expect:
+        configuration.env.get('DEBUG') == '1'
+        configuration.env.get('LAMBDA_EXECUTOR') == 'local'
+    }
+
+}


### PR DESCRIPTION
This PR fixes the issue with the Micronaut converter that applies hyphened type conversion on the keys of the env map. It makes a configuration like this:

```
localstack:
  env:
    DEBUG: 1
    LAMBDA_EXPORTER: local
```

to be represented as the following map:

```
{debug: 1, lamdba-exporter: local}
```

It means that when we run an integration test and we export custom env variables, they are exported inside the container in the incorrect format.