### PR TITLE
Allow adding tags on emails

### DIFF
--- a/docs/guide/src/docs/asciidoc/ses.adoc
+++ b/docs/guide/src/docs/asciidoc/ses.adoc
@@ -55,11 +55,12 @@ include::{root-dir}/subprojects/micronaut-amazon-awssdk-ses/src/test/groovy/com/
 <3> Define the from address
 <4> Define one or more recipients
 <5> Define HTML body (alternatively you can declare plain text body as well)
-<6> Build an attachment
-<7> Define the location of the file to be sent
-<8> Define the file name (optional - deduced from the file)
-<9> Define the mime type (usually optional - deduced from the file)
-<10> Define the description of the file (optional)
+<6> Define tags for the email, they will be included in SES events
+<7> Build an attachment
+<8> Define the location of the file to be sent
+<9> Define the file name (optional - deduced from the file)
+<10> Define the mime type (usually optional - deduced from the file)
+<11> Define the description of the file (optional)
 
 
 [source,java,indent=0,options="nowrap",role="secondary"]
@@ -72,11 +73,12 @@ include::{root-dir}/subprojects/micronaut-amazon-awssdk-ses/src/test/groovy/com/
 <3> Define the from address
 <4> Define one or more recipients
 <5> Define HTML body (alternatively you can declare plain text body as well)
-<6> Build an attachment
-<7> Define the location of the file to be sent
-<8> Define the file name (optional - deduced from the file)
-<9> Define the mime type (usually optional - deduced from the file)
-<10> Define the description of the file (optional)
+<6> Define tags for the email, they will be included in SES events
+<7> Build an attachment
+<8> Define the location of the file to be sent
+<9> Define the file name (optional - deduced from the file)
+<10> Define the mime type (usually optional - deduced from the file)
+<11> Define the description of the file (optional)
 
 Please, see
 https://agorapulse.github.io/micronaut-aws-sdk/api/com/agorapulse/micronaut/amazon/awsses/SimpleEmailService.html[SimpleEmailService AWS SDK 2.x]

--- a/subprojects/micronaut-amazon-awssdk-ses/src/main/java/com/agorapulse/micronaut/amazon/awssdk/ses/DefaultSimpleEmailService.java
+++ b/subprojects/micronaut-amazon-awssdk-ses/src/main/java/com/agorapulse/micronaut/amazon/awssdk/ses/DefaultSimpleEmailService.java
@@ -42,6 +42,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
@@ -190,7 +191,7 @@ public class DefaultSimpleEmailService implements SimpleEmailService {
 
     private List<MessageTag> getCustomTags(TransactionalEmail email) {
         if (email.getTags() == null || email.getTags().isEmpty()) {
-            return null;
+            return Collections.emptyList();
         }
         return email.getTags().entrySet().stream()
             .map(entry -> MessageTag.builder()

--- a/subprojects/micronaut-amazon-awssdk-ses/src/main/java/com/agorapulse/micronaut/amazon/awssdk/ses/TransactionalEmail.java
+++ b/subprojects/micronaut-amazon-awssdk-ses/src/main/java/com/agorapulse/micronaut/amazon/awssdk/ses/TransactionalEmail.java
@@ -20,7 +20,9 @@ package com.agorapulse.micronaut.amazon.awssdk.ses;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 
 /**
@@ -32,6 +34,7 @@ public class TransactionalEmail {
     private String subject = "";
     private String htmlBody = "<html><body></body></html>";
     private String replyTo = "";
+    private Map<String, String> tags = new HashMap<>();
 
     private final List<String> recipients = new ArrayList<>();
     private final List<TransactionalEmailAttachment> attachments = new ArrayList<>();
@@ -76,6 +79,11 @@ public class TransactionalEmail {
         return this;
     }
 
+    public TransactionalEmail tags(Map<String, String> customTags) {
+        this.tags = customTags;
+        return this;
+    }
+
     public String getFrom() {
         return from;
     }
@@ -100,6 +108,10 @@ public class TransactionalEmail {
         return Collections.unmodifiableList(attachments);
     }
 
+    public Map<String, String> getTags() {
+        return tags;
+    }
+
     // CHECKSTYLE:OFF
     @Override
     public String toString() {
@@ -110,6 +122,7 @@ public class TransactionalEmail {
             ", replyTo='" + replyTo + '\'' +
             ", recipients=" + recipients +
             ", attachments=" + attachments +
+            ", tags=" + tags +
             '}';
     }
     // CHECKSTYLE:ON

--- a/subprojects/micronaut-amazon-awssdk-ses/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/ses/SendEmailSpec.groovy
+++ b/subprojects/micronaut-amazon-awssdk-ses/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/ses/SendEmailSpec.groovy
@@ -43,6 +43,7 @@ class SendEmailSpec extends Specification {
             file.createNewFile()
             file.text = 'not a real PDF'
             String thePath = file.canonicalPath
+            Map<String, String> mapOfTags = [myTagKey: 'myTagValue']
         when:
             // tag::builder[]
             EmailDeliveryStatus status = service.send {                                 // <1>
@@ -50,11 +51,12 @@ class SendEmailSpec extends Specification {
                 from 'subscribe@groovycalamari.com'                                     // <3>
                 to 'me@sergiodelamo.com'                                                // <4>
                 htmlBody '<p>This is an example body</p>'                               // <5>
-                attachment {                                                            // <6>
-                    filepath thePath                                                    // <7>
-                    filename 'test.pdf'                                                 // <8>
-                    mimeType 'application/pdf'                                          // <9>
-                    description 'An example pdf'                                        // <10>
+                tags mapOfTags                                                               // <6>
+                attachment {                                     // <7>
+                    filepath thePath                                                         // <8>
+                    filename 'test.pdf'                                              // <9>
+                    mimeType 'application/pdf'                                          // <10>
+                    description 'An example pdf'                                        // <11>
                 }
             }
             // end::builder[]

--- a/subprojects/micronaut-amazon-awssdk-ses/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/ses/SendEmailTest.java
+++ b/subprojects/micronaut-amazon-awssdk-ses/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/ses/SendEmailTest.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Collections;
+import java.util.Map;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -61,11 +62,12 @@ public class SendEmailTest {
                 .from("subscribe@groovycalamari.com")                                   // <3>
                 .to("me@sergiodelamo.com")                                              // <4>
                 .htmlBody("<p>This is an example body</p>")                             // <5>
-                .attachment(a ->                                                        // <6>
-                    a.filepath(filepath)                                                // <7>
-                        .filename("test.pdf")                                           // <8>
-                        .mimeType("application/pdf")                                    // <9>
-                        .description("An example pdf")                                  // <10>
+                .tags(Map.of("myTagKey", "myTagValue"))                         // <6>
+                .attachment(a ->                                                        // <7>
+                    a.filepath(filepath)                                                // <8>
+                        .filename("test.pdf")                                           // <9>
+                        .mimeType("application/pdf")                                    // <10>
+                        .description("An example pdf")                                  // <11>
                 )
         );
         // end::builder[]

--- a/subprojects/micronaut-amazon-awssdk-ses/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/ses/SendEmailTest.java
+++ b/subprojects/micronaut-amazon-awssdk-ses/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/ses/SendEmailTest.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.mockito.Mockito.mock;
@@ -55,6 +56,8 @@ public class SendEmailTest {
 
         Files.write(file.toPath(), Collections.singletonList("not a real PDF"));
         String filepath = file.getCanonicalPath();
+        Map<String, String> mapOfTags = new HashMap<>();
+        mapOfTags.put("myTagKey", "myTagValue");
 
         // tag::builder[]
         EmailDeliveryStatus status = service.send(e ->                                  // <1>
@@ -62,7 +65,7 @@ public class SendEmailTest {
                 .from("subscribe@groovycalamari.com")                                   // <3>
                 .to("me@sergiodelamo.com")                                              // <4>
                 .htmlBody("<p>This is an example body</p>")                             // <5>
-                .tags(Map.of("myTagKey", "myTagValue"))                         // <6>
+                .tags(mapOfTags)                                                        // <6>
                 .attachment(a ->                                                        // <7>
                     a.filepath(filepath)                                                // <8>
                         .filename("test.pdf")                                           // <9>

--- a/subprojects/micronaut-amazon-awssdk-ses/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/ses/SimpleEmailServiceSpec.groovy
+++ b/subprojects/micronaut-amazon-awssdk-ses/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/ses/SimpleEmailServiceSpec.groovy
@@ -44,12 +44,15 @@ class SimpleEmailServiceSpec extends Specification {
     )
 
     void "test transactionalEmailWithClosure"() {
+        given:
+        Map<String, String> customTags = [key1: 'value1', key2: 'value2']
         when:
         TransactionalEmail transactionalEmail = SimpleEmailService.email {
             subject 'Hi Paul'
             from 'subscribe@groovycalamari.com'
             to 'me@sergiodelamo.com'
             htmlBody '<p>This is an example body</p>'
+            tags customTags
             attachment {
                 filename 'test.pdf'
                 filepath '/tmp/test.pdf'
@@ -64,6 +67,7 @@ class SimpleEmailServiceSpec extends Specification {
         transactionalEmail.htmlBody == '<p>This is an example body</p>'
         transactionalEmail.from == 'subscribe@groovycalamari.com'
         transactionalEmail.recipients == ['me@sergiodelamo.com']
+        transactionalEmail.tags == [key1: 'value1', key2: 'value2']
         transactionalEmail.attachments.size() == 1
         transactionalEmail.attachments.first().filename == 'test.pdf'
         transactionalEmail.attachments.first().filepath == '/tmp/test.pdf'
@@ -82,6 +86,7 @@ class SimpleEmailServiceSpec extends Specification {
             htmlBody '<p>This is an example body</p>'
             to 'me@sergiodelamo.com'
             from 'subscribe@groovycalamari.com'
+            tags customTags
             attachment {
                 filepath f.absolutePath
             }
@@ -93,6 +98,7 @@ class SimpleEmailServiceSpec extends Specification {
         transactionalEmail.htmlBody == '<p>This is an example body</p>'
         transactionalEmail.from == 'subscribe@groovycalamari.com'
         transactionalEmail.recipients == ['me@sergiodelamo.com']
+        transactionalEmail.tags == [key1: 'value1', key2: 'value2']
         transactionalEmail.attachments.size() == 1
         transactionalEmail.attachments.first().filename == 'groovylogo.png'
         transactionalEmail.attachments.first().filepath == f.absolutePath

--- a/subprojects/micronaut-aws-sdk-ag-ws/src/test/groovy/com/agorapulse/micronaut/aws/apigateway/ws/LambdaEchoFunctionSpec.groovy
+++ b/subprojects/micronaut-aws-sdk-ag-ws/src/test/groovy/com/agorapulse/micronaut/aws/apigateway/ws/LambdaEchoFunctionSpec.groovy
@@ -33,7 +33,7 @@ import spock.lang.Specification
  */
 @Ignore
 @Remember(
-    value = '2023-06-01',
+    value = '2024-06-01',
     description = 'Try to fix this test or remove this feature completely'
 )
 class LambdaEchoFunctionSpec extends Specification {

--- a/subprojects/micronaut-aws-sdk-ses/src/main/groovy/com/agorapulse/micronaut/aws/ses/DefaultSimpleEmailService.groovy
+++ b/subprojects/micronaut-aws-sdk-ses/src/main/groovy/com/agorapulse/micronaut/aws/ses/DefaultSimpleEmailService.groovy
@@ -149,6 +149,7 @@ class DefaultSimpleEmailService implements SimpleEmailService {
 
         rawEmailRequest.destinations = email.recipients
         rawEmailRequest.source = email.from ?: configuration.sourceEmail.orElse(null)
+        rawEmailRequest.tags = getTags(email)
 
         return handleSend(email) {
             client.sendRawEmail(rawEmailRequest)
@@ -184,7 +185,19 @@ class DefaultSimpleEmailService implements SimpleEmailService {
             if (email.replyTo) {
                 sendEmailRequest.replyToAddresses = singletonList(email.replyTo)
             }
+            sendEmailRequest.tags = getTags(email)
             client.sendEmail(sendEmailRequest)
+        }
+    }
+
+    private List<MessageTag> getTags(TransactionalEmail email) {
+        if (!email.getTags()) {
+            return null
+        }
+        return email.getTags().collect { entry ->
+            new MessageTag()
+                .withName(entry.getKey())
+                .withValue(entry.getValue())
         }
     }
 

--- a/subprojects/micronaut-aws-sdk-ses/src/main/groovy/com/agorapulse/micronaut/aws/ses/DefaultSimpleEmailService.groovy
+++ b/subprojects/micronaut-aws-sdk-ses/src/main/groovy/com/agorapulse/micronaut/aws/ses/DefaultSimpleEmailService.groovy
@@ -191,13 +191,13 @@ class DefaultSimpleEmailService implements SimpleEmailService {
     }
 
     private List<MessageTag> getTags(TransactionalEmail email) {
-        if (!email.getTags()) {
-            return null
+        if (!email.tags) {
+            return []
         }
-        return email.getTags().collect { entry ->
+        return email.tags.collect { entry ->
             new MessageTag()
-                .withName(entry.getKey())
-                .withValue(entry.getValue())
+                .withName(entry.key)
+                .withValue(entry.value)
         }
     }
 

--- a/subprojects/micronaut-aws-sdk-ses/src/main/groovy/com/agorapulse/micronaut/aws/ses/TransactionalEmail.java
+++ b/subprojects/micronaut-aws-sdk-ses/src/main/groovy/com/agorapulse/micronaut/aws/ses/TransactionalEmail.java
@@ -23,7 +23,9 @@ import space.jasan.support.groovy.closure.ConsumerWithDelegate;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 
 /**
@@ -35,6 +37,7 @@ public class TransactionalEmail {
     private String subject = "";
     private String htmlBody = "<html><body></body></html>";
     private String replyTo = "";
+    private Map<String, String> tags = new HashMap<>();
 
     private final List<String> recipients = new ArrayList<>();
     private final List<TransactionalEmailAttachment> attachments = new ArrayList<>();
@@ -83,6 +86,11 @@ public class TransactionalEmail {
         return this;
     }
 
+    public TransactionalEmail tags(Map<String, String> customTags) {
+        this.tags = customTags;
+        return this;
+    }
+
     public String getFrom() {
         return from;
     }
@@ -107,6 +115,10 @@ public class TransactionalEmail {
         return attachments;
     }
 
+    public Map<String, String> getTags() {
+        return tags;
+    }
+
     // CHECKSTYLE:OFF
     @Override
     public String toString() {
@@ -117,6 +129,7 @@ public class TransactionalEmail {
             ", replyTo='" + replyTo + '\'' +
             ", recipients=" + recipients +
             ", attachments=" + attachments +
+            ", tags=" + tags +
             '}';
     }
     // CHECKSTYLE:ON

--- a/subprojects/micronaut-aws-sdk-ses/src/test/groovy/com/agorapulse/micronaut/aws/ses/SendEmailSpec.groovy
+++ b/subprojects/micronaut-aws-sdk-ses/src/test/groovy/com/agorapulse/micronaut/aws/ses/SendEmailSpec.groovy
@@ -46,6 +46,7 @@ class SendEmailSpec extends Specification {
             file.createNewFile()
             file.text = 'not a real PDF'
             String thePath = file.canonicalPath
+            Map<String, String> mapOfTags = [myTagKey: 'myTagValue']
         when:
             // tag::builder[]
             EmailDeliveryStatus status = service.send {                                 // <1>
@@ -53,11 +54,12 @@ class SendEmailSpec extends Specification {
                 from 'subscribe@groovycalamari.com'                                     // <3>
                 to 'me@sergiodelamo.com'                                                // <4>
                 htmlBody '<p>This is an example body</p>'                               // <5>
-                attachment {                                                            // <6>
-                    filepath thePath                                                    // <7>
-                    filename 'test.pdf'                                                 // <8>
-                    mimeType 'application/pdf'                                          // <9>
-                    description 'An example pdf'                                        // <10>
+                tags mapOfTags                                                               // <6>
+                attachment {                                                            // <7>
+                    filepath thePath                                                    // <8>
+                    filename 'test.pdf'                                                 // <9>
+                    mimeType 'application/pdf'                                          // <10>
+                    description 'An example pdf'                                        // <11>
                 }
             }
             // end::builder[]

--- a/subprojects/micronaut-aws-sdk-ses/src/test/groovy/com/agorapulse/micronaut/aws/ses/SendEmailTest.java
+++ b/subprojects/micronaut-aws-sdk-ses/src/test/groovy/com/agorapulse/micronaut/aws/ses/SendEmailTest.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Collections;
+import java.util.Map;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -62,11 +63,12 @@ public class SendEmailTest {
                 .from("subscribe@groovycalamari.com")                                   // <3>
                 .to("me@sergiodelamo.com")                                              // <4>
                 .htmlBody("<p>This is an example body</p>")                             // <5>
-                .attachment(a ->                                                        // <6>
-                    a.filepath(filepath)                                                // <7>
-                        .filename("test.pdf")                                           // <8>
-                        .mimeType("application/pdf")                                    // <9>
-                        .description("An example pdf")                                  // <10>
+                .tags(Map.of("myTagKey", "myTagValue"))                         // <6>
+                .attachment(a ->                                                        // <7>
+                    a.filepath(filepath)                                                // <8>
+                        .filename("test.pdf")                                           // <9>
+                        .mimeType("application/pdf")                                    // <10>
+                        .description("An example pdf")                                  // <11>
                 )
         );
         // end::builder[]

--- a/subprojects/micronaut-aws-sdk-ses/src/test/groovy/com/agorapulse/micronaut/aws/ses/SendEmailTest.java
+++ b/subprojects/micronaut-aws-sdk-ses/src/test/groovy/com/agorapulse/micronaut/aws/ses/SendEmailTest.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.mockito.Mockito.mock;
@@ -56,6 +57,8 @@ public class SendEmailTest {
         file.createNewFile();
         Files.write(file.toPath(), Collections.singletonList("not a real PDF"));
         String filepath = file.getCanonicalPath();
+        Map<String, String> mapOfTags = new HashMap<>();
+        mapOfTags.put("myTagKey", "myTagValue");
 
         // tag::builder[]
         EmailDeliveryStatus status = service.send(e ->                                  // <1>
@@ -63,7 +66,7 @@ public class SendEmailTest {
                 .from("subscribe@groovycalamari.com")                                   // <3>
                 .to("me@sergiodelamo.com")                                              // <4>
                 .htmlBody("<p>This is an example body</p>")                             // <5>
-                .tags(Map.of("myTagKey", "myTagValue"))                         // <6>
+                .tags(mapOfTags)                                                        // <6>
                 .attachment(a ->                                                        // <7>
                     a.filepath(filepath)                                                // <8>
                         .filename("test.pdf")                                           // <9>

--- a/subprojects/micronaut-aws-sdk-ses/src/test/groovy/com/agorapulse/micronaut/aws/ses/SimpleEmailServiceSpec.groovy
+++ b/subprojects/micronaut-aws-sdk-ses/src/test/groovy/com/agorapulse/micronaut/aws/ses/SimpleEmailServiceSpec.groovy
@@ -41,12 +41,15 @@ class SimpleEmailServiceSpec extends Specification {
     ))
 
     void "test transactionalEmailWithClosure"() {
+        given:
+        Map<String, String> customTags = [key1: 'value1', key2: 'value2']
         when:
         TransactionalEmail transactionalEmail = SimpleEmailService.email {
             subject 'Hi Paul'
             from 'subscribe@groovycalamari.com'
             to 'me@sergiodelamo.com'
             htmlBody '<p>This is an example body</p>'
+            tags customTags
             attachment {
                 filename 'test.pdf'
                 filepath '/tmp/test.pdf'
@@ -61,6 +64,7 @@ class SimpleEmailServiceSpec extends Specification {
         transactionalEmail.htmlBody == '<p>This is an example body</p>'
         transactionalEmail.from == 'subscribe@groovycalamari.com'
         transactionalEmail.recipients == ['me@sergiodelamo.com']
+        transactionalEmail.tags == [key1: 'value1', key2: 'value2']
         transactionalEmail.attachments.size() == 1
         transactionalEmail.attachments.first().filename == 'test.pdf'
         transactionalEmail.attachments.first().filepath == '/tmp/test.pdf'
@@ -79,6 +83,7 @@ class SimpleEmailServiceSpec extends Specification {
             htmlBody '<p>This is an example body</p>'
             to 'me@sergiodelamo.com'
             from 'subscribe@groovycalamari.com'
+            tags customTags
             attachment {
                 filepath f.absolutePath
             }
@@ -90,6 +95,7 @@ class SimpleEmailServiceSpec extends Specification {
         transactionalEmail.htmlBody == '<p>This is an example body</p>'
         transactionalEmail.from == 'subscribe@groovycalamari.com'
         transactionalEmail.recipients == ['me@sergiodelamo.com']
+        transactionalEmail.tags == [key1: 'value1', key2: 'value2']
         transactionalEmail.attachments.size() == 1
         transactionalEmail.attachments.first().filename == 'groovylogo.png'
         transactionalEmail.attachments.first().filepath == f.absolutePath


### PR DESCRIPTION
Adding tags when sending emails with SES allows identifying email sending events