### PR TITLE
[124036] Update kinesis lib to not overide consumerFilterKey

### DIFF
--- a/subprojects/micronaut-amazon-awssdk-kinesis/src/main/java/com/agorapulse/micronaut/amazon/awssdk/kinesis/DefaultKinesisService.java
+++ b/subprojects/micronaut-amazon-awssdk-kinesis/src/main/java/com/agorapulse/micronaut/amazon/awssdk/kinesis/DefaultKinesisService.java
@@ -208,7 +208,7 @@ class DefaultKinesisService implements KinesisService {
 
     @Override
     public PutRecordResponse putEvent(String streamName, Event event, String sequenceNumberForOrdering) {
-        overideConsumerFilterKeyIfEmpty(event, configuration.getConsumerFilterKey());
+        setConsumerFilterKeyIfEmpty(event, configuration.getConsumerFilterKey());
 
         try {
             return putRecord(streamName, event.getPartitionKey(), objectMapper.writeValueAsString(event), sequenceNumberForOrdering);
@@ -223,7 +223,7 @@ class DefaultKinesisService implements KinesisService {
             throw new IllegalArgumentException("Max put events size is " + MAX_PUT_RECORDS_SIZE);
         }
         return putRecords(streamName, events.stream().map(event -> {
-            overideConsumerFilterKeyIfEmpty(event, configuration.getConsumerFilterKey());
+            setConsumerFilterKeyIfEmpty(event, configuration.getConsumerFilterKey());
 
             try {
                 return PutRecordsRequestEntry.builder()
@@ -286,7 +286,7 @@ class DefaultKinesisService implements KinesisService {
         }
     }
 
-    private void overideConsumerFilterKeyIfEmpty(Event event, String consumerFilterKey) {
+    private void setConsumerFilterKeyIfEmpty(Event event, String consumerFilterKey) {
         if (StringUtils.isEmpty(event.getConsumerFilterKey()) && !StringUtils.isEmpty(consumerFilterKey)) {
             event.setConsumerFilterKey(consumerFilterKey);
         }

--- a/subprojects/micronaut-amazon-awssdk-kinesis/src/main/java/com/agorapulse/micronaut/amazon/awssdk/kinesis/DefaultKinesisService.java
+++ b/subprojects/micronaut-amazon-awssdk-kinesis/src/main/java/com/agorapulse/micronaut/amazon/awssdk/kinesis/DefaultKinesisService.java
@@ -208,9 +208,7 @@ class DefaultKinesisService implements KinesisService {
 
     @Override
     public PutRecordResponse putEvent(String streamName, Event event, String sequenceNumberForOrdering) {
-        if (!StringUtils.isEmpty(configuration.getConsumerFilterKey())) {
-            event.setConsumerFilterKey(configuration.getConsumerFilterKey());
-        }
+        overideConsumerFilterKeyIfEmpty(event, configuration.getConsumerFilterKey());
 
         try {
             return putRecord(streamName, event.getPartitionKey(), objectMapper.writeValueAsString(event), sequenceNumberForOrdering);
@@ -225,9 +223,7 @@ class DefaultKinesisService implements KinesisService {
             throw new IllegalArgumentException("Max put events size is " + MAX_PUT_RECORDS_SIZE);
         }
         return putRecords(streamName, events.stream().map(event -> {
-            if (!StringUtils.isEmpty(configuration.getConsumerFilterKey())) {
-                event.setConsumerFilterKey(configuration.getConsumerFilterKey());
-            }
+            overideConsumerFilterKeyIfEmpty(event, configuration.getConsumerFilterKey());
 
             try {
                 return PutRecordsRequestEntry.builder()
@@ -290,4 +286,9 @@ class DefaultKinesisService implements KinesisService {
         }
     }
 
+    private void overideConsumerFilterKeyIfEmpty(Event event, String consumerFilterKey) {
+        if (StringUtils.isEmpty(event.getConsumerFilterKey()) && !StringUtils.isEmpty(consumerFilterKey)) {
+            event.setConsumerFilterKey(consumerFilterKey);
+        }
+    }
 }

--- a/subprojects/micronaut-aws-sdk-kinesis/src/main/groovy/com/agorapulse/micronaut/aws/kinesis/DefaultKinesisService.java
+++ b/subprojects/micronaut-aws-sdk-kinesis/src/main/groovy/com/agorapulse/micronaut/aws/kinesis/DefaultKinesisService.java
@@ -198,7 +198,7 @@ class DefaultKinesisService implements KinesisService {
 
     @Override
     public PutRecordResult putEvent(String streamName, Event event, String sequenceNumberForOrdering) {
-        overideConsumerFilterKeyIfEmpty(event, configuration.getConsumerFilterKey());
+        setConsumerFilterKeyIfEmpty(event, configuration.getConsumerFilterKey());
 
         try {
             return putRecord(streamName, event.getPartitionKey(), objectMapper.writeValueAsString(event), sequenceNumberForOrdering);
@@ -213,7 +213,7 @@ class DefaultKinesisService implements KinesisService {
             throw new IllegalArgumentException("Max put events size is " + MAX_PUT_RECORDS_SIZE);
         }
         return putRecords(streamName, events.stream().map(event -> {
-            overideConsumerFilterKeyIfEmpty(event, configuration.getConsumerFilterKey());
+            setConsumerFilterKeyIfEmpty(event, configuration.getConsumerFilterKey());
 
             try {
                 ByteBuffer data = ByteBuffer.wrap(objectMapper.writeValueAsString(event).getBytes());
@@ -285,7 +285,7 @@ class DefaultKinesisService implements KinesisService {
     private final KinesisConfiguration configuration;
     private final ObjectMapper objectMapper;
 
-    private void overideConsumerFilterKeyIfEmpty(Event event, String consumerFilterKey) {
+    private void setConsumerFilterKeyIfEmpty(Event event, String consumerFilterKey) {
         if (StringUtils.isEmpty(event.getConsumerFilterKey()) && !StringUtils.isEmpty(consumerFilterKey)) {
             event.setConsumerFilterKey(consumerFilterKey);
         }

--- a/subprojects/micronaut-aws-sdk-kinesis/src/main/groovy/com/agorapulse/micronaut/aws/kinesis/DefaultKinesisService.java
+++ b/subprojects/micronaut-aws-sdk-kinesis/src/main/groovy/com/agorapulse/micronaut/aws/kinesis/DefaultKinesisService.java
@@ -198,9 +198,7 @@ class DefaultKinesisService implements KinesisService {
 
     @Override
     public PutRecordResult putEvent(String streamName, Event event, String sequenceNumberForOrdering) {
-        if (!StringUtils.isEmpty(configuration.getConsumerFilterKey())) {
-            event.setConsumerFilterKey(configuration.getConsumerFilterKey());
-        }
+        overideConsumerFilterKeyIfEmpty(event, configuration.getConsumerFilterKey());
 
         try {
             return putRecord(streamName, event.getPartitionKey(), objectMapper.writeValueAsString(event), sequenceNumberForOrdering);
@@ -215,9 +213,7 @@ class DefaultKinesisService implements KinesisService {
             throw new IllegalArgumentException("Max put events size is " + MAX_PUT_RECORDS_SIZE);
         }
         return putRecords(streamName, events.stream().map(event -> {
-            if (!StringUtils.isEmpty(configuration.getConsumerFilterKey())) {
-                event.setConsumerFilterKey(configuration.getConsumerFilterKey());
-            }
+            overideConsumerFilterKeyIfEmpty(event, configuration.getConsumerFilterKey());
 
             try {
                 ByteBuffer data = ByteBuffer.wrap(objectMapper.writeValueAsString(event).getBytes());
@@ -288,4 +284,10 @@ class DefaultKinesisService implements KinesisService {
     private final AmazonKinesis client;
     private final KinesisConfiguration configuration;
     private final ObjectMapper objectMapper;
+
+    private void overideConsumerFilterKeyIfEmpty(Event event, String consumerFilterKey) {
+        if (StringUtils.isEmpty(event.getConsumerFilterKey()) && !StringUtils.isEmpty(consumerFilterKey)) {
+            event.setConsumerFilterKey(consumerFilterKey);
+        }
+    }
 }


### PR DESCRIPTION
Context :
in the library used to push event in kinesis stream, the method putEvent overrides the consumerFilterKey. We don't want this method to overide the consumerFilterKey. What we want is to set the consumerFilterKey only if the event has not already a consumerFilterKey
This will allow to listen events in local that come from beta kinesis

Dev :
- check if event has alreadyConsumerfilterkey set, if not then set it
