### PR TITLE
ability to simply add TTL field

### DIFF
--- a/docs/guide/src/docs/asciidoc/dynamodb.adoc
+++ b/docs/guide/src/docs/asciidoc/dynamodb.adoc
@@ -76,6 +76,7 @@ include::{root-dir}/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy
 <4> The secondary indices are generated automatically if not present
 <5> If the secondary indices are generated then the projection type must be specified (the default is KEYS_ONLY)
 <6> The secondary indices can be read only if you derive them from the other attributes
+<7> You can use `@TimeToLive` annotation to specify the attribute which will be used for TTL. The annotation used on class level, the `Instant.now()` will be used as a reference time.
 
 
 [source,java,indent=0,options="nowrap",role="secondary"]
@@ -89,6 +90,7 @@ include::{root-dir}/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy
 <4> The secondary indices are generated automatically if not present
 <5> If the secondary indices are generated then the projection type must be specified (the default is KEYS_ONLY)
 <6> The secondary indices can be read only if you derive them from the other attributes
+<7> You can use `@TimeToLive` annotation to specify the attribute which will be used for TTL. The annotation used on class level, the `Instant.now()` will be used as a reference time.
 
 [source,kotlin,indent=0,options="nowrap",role="secondary"]
 .Kotlin
@@ -101,6 +103,9 @@ include::{root-dir}/subprojects/micronaut-amazon-awssdk-dynamodb-kotlin/src/test
 <4> The secondary indices are generated automatically if not present
 <5> If the secondary indices are generated then the projection type must be specified (the default is KEYS_ONLY)
 <6> The secondary indices can be read only if you derive them from the other attributes
+<7> You can use `@TimeToLive` annotation to specify the attribute which will be used for TTL. The annotation used on class level, the `Instant.now()` will be used as a reference time.
+
+WARNING: The `@TimeToLive` annotation only adds read only attribute to the entity. You need to enable TTL on the table manually.
 
 ==== Declarative Services with `@Service`
 

--- a/subprojects/micronaut-amazon-awssdk-dynamodb-kotlin/src/test/kotlin/com/agorapulse/micronaut/amazon/awssdk/dynamodb/kotlin/DynamoDBEntity.kt
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb-kotlin/src/test/kotlin/com/agorapulse/micronaut/amazon/awssdk/dynamodb/kotlin/DynamoDBEntity.kt
@@ -20,6 +20,7 @@ package com.agorapulse.micronaut.amazon.awssdk.dynamodb.kotlin
 import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.*
 import io.micronaut.core.annotation.Introspected
 import software.amazon.awssdk.services.dynamodb.model.ProjectionType
+import java.time.Instant
 import java.util.*
 
 @Introspected                                                                           // <1>
@@ -47,6 +48,9 @@ class DynamoDBEntity {
     fun getGlobalIndex(): String {
         return "$parentId:$id"
     }
+
+    @TimeToLive("365d")                                                                 // <7>
+    var created: Instant? = null
 
     companion object {
         const val DATE_INDEX = "date"

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/main/java/com/agorapulse/micronaut/amazon/awssdk/dynamodb/annotation/TimeToLive.java
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/main/java/com/agorapulse/micronaut/amazon/awssdk/dynamodb/annotation/TimeToLive.java
@@ -1,0 +1,63 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2018-2025 Agorapulse.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation;
+
+import java.lang.annotation.*;
+
+
+/**
+ * Specifies the time to live for entity.
+ * <p>
+ * When a class is annotated with then a new attribute specified by {@link #attributeName()} is added to the entity every time
+ * the entity is persisted. The value of the attribute is set to the current time plus the duration specified by {@link #value()}.
+ * The value of the attribute is updated every time the entity is persisted.
+ * </p>
+ * <p>
+ * When a field is annotated with the annotation, the field value is used to determine the time to live for the entity.
+ * The value is computed by adding the value of the field plus the duration specified by {@link #value()}. The value of the field
+ * is updated every time the entity is persisted.
+ * </p>
+ */
+@Inherited
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.ANNOTATION_TYPE, ElementType.FIELD, ElementType.METHOD, ElementType.TYPE})
+public @interface TimeToLive {
+
+    /**
+     * The duration string that represents the time to live for the item.
+     *
+     * @return the duration string that represents the time to live for the item
+     */
+    String value();
+
+    /**
+     * The name of the attribute that represents the time to live for the item.
+     */
+    String attributeName() default "ttl";
+
+    /**
+     * The format of the time if the annotated member is a field of type {@link String}.
+     * By default, the time will be parsed using {@link java.time.Instant#parse(CharSequence)}.
+     * The value has no effect if the annotated member is not a field of type {@link String} or the annotation is used on a type.
+     *
+     * @return the format of the time if the annotated member is a field of type {@link String}
+     */
+    String format() default "";
+
+}

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/main/java/com/agorapulse/micronaut/amazon/awssdk/dynamodb/schema/BeanIntrospectionTableSchema.java
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/main/java/com/agorapulse/micronaut/amazon/awssdk/dynamodb/schema/BeanIntrospectionTableSchema.java
@@ -227,7 +227,7 @@ public final class BeanIntrospectionTableSchema<T> extends WrappedTableSchema<T,
         return builder.build();
     }
 
-    private static <T> StaticAttribute<T,?> createTtlAttributeFromTopLevelAnnotation(Class<T> type, AnnotationValue<TimeToLive> ttl, BeanContext beanContext) {
+    private static <T> StaticAttribute<T, ?> createTtlAttributeFromTopLevelAnnotation(Class<T> type, AnnotationValue<TimeToLive> ttl, BeanContext beanContext) {
         long durationInSeconds = beanContext.getConversionService().convertRequired(ttl.getRequiredValue(String.class), Duration.class).getSeconds();
         return StaticAttribute.builder(type, Long.class)
             .name(ttl.stringValue("attributeName").filter(StringUtils::isNotEmpty).orElse("ttl"))
@@ -236,7 +236,7 @@ public final class BeanIntrospectionTableSchema<T> extends WrappedTableSchema<T,
             .build();
     }
 
-    private static <T> StaticAttribute<T,?> createTtlAttributeFromFieldAnnotation(Class<T> type, AnnotationValue<TimeToLive> ttl, BeanProperty<T, ?> property, BeanContext beanContext) {
+    private static <T> StaticAttribute<T, ?> createTtlAttributeFromFieldAnnotation(Class<T> type, AnnotationValue<TimeToLive> ttl, BeanProperty<T, ?> property, BeanContext beanContext) {
         Duration duration = beanContext.getConversionService().convertRequired(ttl.getRequiredValue(String.class), Duration.class);
         Function<T, Instant> toInstant = createInstantGetter(ttl, property, beanContext);
 
@@ -249,7 +249,7 @@ public final class BeanIntrospectionTableSchema<T> extends WrappedTableSchema<T,
 
     private static <T> Function<T, Instant> createInstantGetter(AnnotationValue<TimeToLive> ttl, BeanProperty<T, ?> property, BeanContext beanContext) {
         if (Instant.class.isAssignableFrom(property.getType())) {
-            return instance -> ((Instant) property.get(instance));
+            return instance -> (Instant) property.get(instance);
         }
 
         if (CharSequence.class.isAssignableFrom(property.getType())) {

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/main/java/com/agorapulse/micronaut/amazon/awssdk/dynamodb/schema/BeanIntrospectionTableSchema.java
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/main/java/com/agorapulse/micronaut/amazon/awssdk/dynamodb/schema/BeanIntrospectionTableSchema.java
@@ -242,7 +242,7 @@ public final class BeanIntrospectionTableSchema<T> extends WrappedTableSchema<T,
 
         return StaticAttribute.builder(type, Long.class)
             .name(ttl.stringValue("attributeName").filter(StringUtils::isNotEmpty).orElse("ttl"))
-            .getter(instance -> Optional.of(toInstant.apply(instance)).orElseGet(Instant::now).plus(duration).getEpochSecond())
+            .getter(instance -> Optional.ofNullable(toInstant.apply(instance)).orElseGet(Instant::now).plus(duration).getEpochSecond())
             .setter((instance, value) -> { })
             .build();
     }

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/main/java/com/agorapulse/micronaut/amazon/awssdk/dynamodb/schema/BeanIntrospectionTableSchema.java
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/main/java/com/agorapulse/micronaut/amazon/awssdk/dynamodb/schema/BeanIntrospectionTableSchema.java
@@ -27,6 +27,7 @@ import io.micronaut.core.beans.BeanIntrospection;
 import io.micronaut.core.beans.BeanIntrospector;
 import io.micronaut.core.beans.BeanProperty;
 import io.micronaut.core.type.Argument;
+import io.micronaut.core.util.StringUtils;
 import software.amazon.awssdk.annotations.SdkPublicApi;
 import software.amazon.awssdk.annotations.ThreadSafe;
 import software.amazon.awssdk.enhanced.dynamodb.AttributeConverter;
@@ -59,13 +60,13 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbUpdat
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Type;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
+import java.time.*;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoField;
+import java.time.temporal.TemporalAccessor;
+import java.util.*;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -206,15 +207,81 @@ public final class BeanIntrospectionTableSchema<T> extends WrappedTableSchema<T,
             builder.attributeConverterProviders(new LegacyAttributeConverterProvider());
         }
 
-        List<StaticAttribute<T, ?>> attributes = introspection.getBeanProperties().stream()
+        List<StaticAttribute<T, ?>> attributes = new ArrayList<>();
+
+        introspection.getBeanProperties().stream()
             .filter(p -> isMappableProperty(beanClass, p))
-            .map(propertyDescriptor -> extractAttributeFromProperty(beanClass, metaTableSchemaCache, builder, propertyDescriptor, beanContext))
+            .map(propertyDescriptor -> {
+                propertyDescriptor.findAnnotation(TimeToLive.class).ifPresent(timeToLive -> {
+                    attributes.add(createTtlAttributeFromFieldAnnotation(beanClass, timeToLive, propertyDescriptor, beanContext));
+                });
+                return extractAttributeFromProperty(beanClass, metaTableSchemaCache, builder, propertyDescriptor, beanContext);
+            })
             .filter(Objects::nonNull)
-            .collect(Collectors.toList());
+            .forEach(attributes::add);
+
+        introspection.findAnnotation(TimeToLive.class).ifPresent(ttl -> attributes.add(createTtlAttributeFromTopLevelAnnotation(beanClass, ttl, beanContext)));
 
         builder.attributes(attributes);
 
         return builder.build();
+    }
+
+    private static <T> StaticAttribute<T,?> createTtlAttributeFromTopLevelAnnotation(Class<T> type, AnnotationValue<TimeToLive> ttl, BeanContext beanContext) {
+        long durationInSeconds = beanContext.getConversionService().convertRequired(ttl.getRequiredValue(String.class), Duration.class).getSeconds();
+        return StaticAttribute.builder(type, Long.class)
+            .name(ttl.stringValue("attributeName").filter(StringUtils::isNotEmpty).orElse("ttl"))
+            .getter(instance -> System.currentTimeMillis() / 1000 + durationInSeconds)
+            .setter((instance, value) -> { })
+            .build();
+    }
+
+    private static <T> StaticAttribute<T,?> createTtlAttributeFromFieldAnnotation(Class<T> type, AnnotationValue<TimeToLive> ttl, BeanProperty<T, ?> property, BeanContext beanContext) {
+        Duration duration = beanContext.getConversionService().convertRequired(ttl.getRequiredValue(String.class), Duration.class);
+        Function<T, Instant> toInstant = createInstantGetter(ttl, property, beanContext);
+
+        return StaticAttribute.builder(type, Long.class)
+            .name(ttl.stringValue("attributeName").filter(StringUtils::isNotEmpty).orElse("ttl"))
+            .getter(instance -> Optional.of(toInstant.apply(instance)).orElseGet(Instant::now).plus(duration).getEpochSecond())
+            .setter((instance, value) -> { })
+            .build();
+    }
+
+    private static <T> Function<T, Instant> createInstantGetter(AnnotationValue<TimeToLive> ttl, BeanProperty<T, ?> property, BeanContext beanContext) {
+        if (Instant.class.isAssignableFrom(property.getType())) {
+            return instance -> ((Instant) property.get(instance));
+        }
+
+        if (CharSequence.class.isAssignableFrom(property.getType())) {
+            DateTimeFormatter formatter = ttl
+                .stringValue("format")
+                .filter(StringUtils::isNotEmpty)
+                .map(DateTimeFormatter::ofPattern)
+                .orElse(DateTimeFormatter.ISO_INSTANT);
+
+            return instance -> {
+                TemporalAccessor parsed = formatter.parse((CharSequence) property.get(instance));
+                if (!parsed.isSupported(ChronoField.INSTANT_SECONDS)) {
+                    if (parsed.isSupported(ChronoField.HOUR_OF_DAY)) {
+                        return LocalDateTime.from(parsed).atZone(ZoneOffset.UTC).toInstant();
+                    }
+                    return LocalDate.from(parsed).atStartOfDay(ZoneOffset.UTC).toInstant();
+                }
+                return Instant.from(parsed);
+            };
+        }
+
+        if (Number.class.isAssignableFrom(property.getType())) {
+            return instance -> Instant.ofEpochMilli(((Number) property.get(instance)).longValue());
+        }
+
+        if (beanContext.getConversionService().canConvert(property.getType(), Instant.class)) {
+            return instance -> beanContext.getConversionService().convert(property.get(instance), Instant.class).orElseThrow(
+                () -> new IllegalArgumentException("Failed to convert " + property.get(instance) + " to Instant for field " + property + " annotated with @TimeToLive " + ttl
+            ));
+        }
+
+        throw new IllegalArgumentException("TimeToLive annotation can only be used on fields of type Instant, String or Long or any type that can be converted using ConversionService but was used on " + property);
     }
 
     private static <T, P> StaticAttribute<T, P> extractAttributeFromProperty(

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/DefaultDynamoDBServiceSpec.groovy
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/DefaultDynamoDBServiceSpec.groovy
@@ -89,7 +89,7 @@ class DefaultDynamoDBServiceSpec extends Specification {
         unknownMethodsService.delete('1', '1', '1')
         then:
         IllegalArgumentException e3 = thrown(IllegalArgumentException)
-        e3.message == '''Unknown property somethingElse for DynamoDBEntity{parentId='null', id='null', rangeIndex='null', date=null, number=0, mapProperty={}, stringSetProperty=[]}'''
+        e3.message == '''Unknown property somethingElse for DynamoDBEntity{parentId='null', id='null', rangeIndex='null', date=null, number=0, mapProperty={}, created=null, stringSetProperty=[]}'''
 
         when:
         unknownMethodsService.get('1', '1', '1')

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/DynamoDBEntity.java
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/DynamoDBEntity.java
@@ -17,7 +17,13 @@
  */
 package com.agorapulse.micronaut.amazon.awssdk.dynamodb;
 
-import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.*;
+import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.ConvertedJson;
+import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.PartitionKey;
+import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.Projection;
+import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.SecondaryPartitionKey;
+import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.SecondarySortKey;
+import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.SortKey;
+import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.TimeToLive;
 import io.micronaut.core.annotation.Introspected;
 import software.amazon.awssdk.services.dynamodb.model.ProjectionType;
 

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/DynamoDBEntity.java
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/DynamoDBEntity.java
@@ -17,15 +17,11 @@
  */
 package com.agorapulse.micronaut.amazon.awssdk.dynamodb;
 
-import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.ConvertedJson;
-import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.PartitionKey;
-import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.Projection;
-import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.SecondaryPartitionKey;
-import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.SecondarySortKey;
-import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.SortKey;
+import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.*;
 import io.micronaut.core.annotation.Introspected;
 import software.amazon.awssdk.services.dynamodb.model.ProjectionType;
 
+import java.time.Instant;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -46,6 +42,7 @@ public class DynamoDBEntity implements PlaybookAware {
     private String rangeIndex;
     private Date date;
     private Integer number = 0;
+    private Instant created;
 
     private Map<String, List<String>> mapProperty = new LinkedHashMap<>();
     private Set<String> stringSetProperty = new HashSet<>();
@@ -102,6 +99,15 @@ public class DynamoDBEntity implements PlaybookAware {
         return parentId + ":" + id;
     }
 
+    @TimeToLive("365d")                                                                 // <7>
+    public Instant getCreated() {
+        return created;
+    }
+
+    public void setCreated(Instant created) {
+        this.created = created;
+    }
+
     public Map<String, List<String>> getMapProperty() {
         return mapProperty;
     }
@@ -139,6 +145,7 @@ public class DynamoDBEntity implements PlaybookAware {
             Objects.equals(date, that.date) &&
             Objects.equals(number, that.number) &&
             Objects.equals(mapProperty, that.mapProperty) &&
+            Objects.equals(created, that.created) &&
             Objects.equals(stringSetProperty, that.stringSetProperty);
     }
 
@@ -156,6 +163,7 @@ public class DynamoDBEntity implements PlaybookAware {
             ", date=" + date +
             ", number=" + number +
             ", mapProperty=" + mapProperty +
+            ", created=" + created +
             ", stringSetProperty=" + stringSetProperty +
             '}';
     }

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/groovy/DynamoDBEntity.groovy
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/groovy/DynamoDBEntity.groovy
@@ -57,7 +57,7 @@ class DynamoDBEntity {
         return "$parentId:$id"
     }
 
-    @TimeToLive("365d")                                                                 // <7>
+    @TimeToLive('365d')                                                                 // <7>
     Instant created
 
 }

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/groovy/DynamoDBEntity.groovy
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/groovy/DynamoDBEntity.groovy
@@ -22,10 +22,13 @@ import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.Projection
 import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.SecondaryPartitionKey
 import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.SecondarySortKey
 import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.SortKey
+import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.TimeToLive
 import groovy.transform.Canonical
 import groovy.transform.CompileStatic
 import io.micronaut.core.annotation.Introspected
 import software.amazon.awssdk.services.dynamodb.model.ProjectionType
+
+import java.time.Instant
 
 @Canonical
 @Introspected                                                                           // <1>
@@ -53,5 +56,8 @@ class DynamoDBEntity {
     String getGlobalIndex() {
         return "$parentId:$id"
     }
+
+    @TimeToLive("365d")                                                                 // <7>
+    Instant created
 
 }

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/schema/BeanIntrospectionTableSchemaSpec.groovy
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/schema/BeanIntrospectionTableSchemaSpec.groovy
@@ -32,7 +32,6 @@ import spock.lang.Specification
 import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
-import java.time.LocalDateTime
 import java.time.ZoneOffset
 
 class BeanIntrospectionTableSchemaSpec extends Specification {

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/schema/BeanIntrospectionTableSchemaSpec.groovy
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/schema/BeanIntrospectionTableSchemaSpec.groovy
@@ -24,9 +24,16 @@ import com.agorapulse.micronaut.amazon.awssdk.dynamodb.DynamoDBEntityNoRange
 import com.agorapulse.micronaut.amazon.awssdk.dynamodb.Person
 import com.agorapulse.micronaut.amazon.awssdk.dynamodb.PhoneNumber
 import io.micronaut.context.BeanContext
+import io.micronaut.core.convert.ConversionService
 import software.amazon.awssdk.enhanced.dynamodb.internal.mapper.MetaTableSchemaCache
 import spock.lang.IgnoreIf
 import spock.lang.Specification
+
+import java.time.Duration
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneOffset
 
 class BeanIntrospectionTableSchemaSpec extends Specification {
 
@@ -34,6 +41,7 @@ class BeanIntrospectionTableSchemaSpec extends Specification {
 
     BeanContext context = Mock {
         findBean(_) >> Optional.empty()
+        getConversionService() >> ConversionService.SHARED
     }
 
     void 'read table schema for java class'() {
@@ -41,6 +49,80 @@ class BeanIntrospectionTableSchemaSpec extends Specification {
             BeanIntrospectionTableSchema<DynamoDBEntity> schema = BeanIntrospectionTableSchema.create(DynamoDBEntity, context, cache)
         then:
             schema.attributeNames().size() == 9
+    }
+
+    <T> void '#attribute attribute is added to the class #type when TimeToLive annotation is used with duration #duration'(
+        Class<T> type, String attribute, Duration duration, T instance
+    ) {
+        when:
+            BeanIntrospectionTableSchema<T> schema = BeanIntrospectionTableSchema.create(type, context, cache)
+        then:
+            schema.attributeNames().size() == 3
+            schema.attributeNames().contains(attribute)
+
+        when:
+            long secondsBefore = (long) (System.currentTimeMillis() / 1000L)
+            long ttl = schema.itemToMap(instance, [attribute]).get(attribute).n().toLong()
+            long secondsAfter = (long) (System.currentTimeMillis() / 1000L)
+        then:
+            verifyAll {
+                ttl >= secondsBefore + duration.seconds
+                ttl <= secondsAfter + duration.seconds
+            }
+
+        where:
+            type                | attribute   | duration             | instance
+            EntityWithTtl       | 'ttl'       | Duration.ofDays(30)  | new EntityWithTtl(id: 1L, sortKey: 2L)
+            EntityWithCustomTtl | 'customTtl' | Duration.ofDays(365) | new EntityWithCustomTtl(id: 1L, sortKey: 2L)
+    }
+
+    void 'ttl is added to the class with TimeToLive annotation on the instant field'() {
+        when:
+            BeanIntrospectionTableSchema<EntityWithTtlOnInstantField> schema = BeanIntrospectionTableSchema.create(EntityWithTtlOnInstantField, context, cache)
+        then:
+            schema.attributeNames().size() == 4
+            schema.attributeNames().contains('ttl')
+
+        when:
+            Instant refTime = Instant.now()
+            long ttl = schema.itemToMap(new EntityWithTtlOnInstantField(id: 1L, sortKey: 2L, created: refTime), ['ttl']).get('ttl').n().toLong()
+        then:
+            ttl == (refTime + Duration.ofDays(45)).epochSecond
+    }
+
+    void 'ttl is added to the class with TimeToLive annotation on the string field'() {
+        when:
+            BeanIntrospectionTableSchema<EntityWithTtlOnStringField> schema = BeanIntrospectionTableSchema.create(EntityWithTtlOnStringField, context, cache)
+        then:
+            schema.attributeNames().size() == 4
+            schema.attributeNames().contains('ttl')
+
+        when:
+            String refTime = '2020-01-01T00'
+            long ttl = schema.itemToMap(new EntityWithTtlOnStringField(id: 1L, sortKey: 2L, created: refTime), ['ttl']).get('ttl').n().toLong()
+        then:
+            ttl == (LocalDate.of(2020, 1, 1).atStartOfDay(ZoneOffset.UTC).toInstant() + Duration.ofDays(17)).epochSecond
+    }
+
+    void 'ttl is added to the class with TimeToLive annotation on the long field'() {
+        when:
+            BeanIntrospectionTableSchema<EntityWithTtlOnLongField> schema = BeanIntrospectionTableSchema.create(EntityWithTtlOnLongField, context, cache)
+        then:
+            schema.attributeNames().size() == 4
+            schema.attributeNames().contains('ttl')
+
+        when:
+            Long refTime = LocalDate.of(2020, 1, 1).atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli()
+            long ttl = schema.itemToMap(new EntityWithTtlOnLongField(id: 1L, sortKey: 2L, created: refTime), ['ttl']).get('ttl').n().toLong()
+        then:
+            ttl == (LocalDate.of(2020, 1, 1).atStartOfDay(ZoneOffset.UTC).toInstant() + Duration.ofDays(3)).epochSecond
+    }
+
+    void 'ttl field must be convertable'() {
+        when:
+            BeanIntrospectionTableSchema<EntityWithTtlOnDateField> schema = BeanIntrospectionTableSchema.create(EntityWithTtlOnDateField, context, cache)
+        then:
+            thrown(IllegalArgumentException)
     }
 
     void 'read table schema for java class with nested beans'() {

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/schema/BeanIntrospectionTableSchemaSpec.groovy
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/schema/BeanIntrospectionTableSchemaSpec.groovy
@@ -48,7 +48,7 @@ class BeanIntrospectionTableSchemaSpec extends Specification {
         when:
             BeanIntrospectionTableSchema<DynamoDBEntity> schema = BeanIntrospectionTableSchema.create(DynamoDBEntity, context, cache)
         then:
-            schema.attributeNames().size() == 9
+            schema.attributeNames().size() == 11
     }
 
     <T> void '#attribute attribute is added to the class #type when TimeToLive annotation is used with duration #duration'(

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/schema/BeanIntrospectionTableSchemaSpec.groovy
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/schema/BeanIntrospectionTableSchemaSpec.groovy
@@ -40,7 +40,7 @@ class BeanIntrospectionTableSchemaSpec extends Specification {
 
     BeanContext context = Mock {
         findBean(_) >> Optional.empty()
-        getConversionService() >> ConversionService.SHARED
+        conversionService >> ConversionService.SHARED
     }
 
     void 'read table schema for java class'() {
@@ -119,7 +119,7 @@ class BeanIntrospectionTableSchemaSpec extends Specification {
 
     void 'ttl field must be convertable'() {
         when:
-            BeanIntrospectionTableSchema<EntityWithTtlOnDateField> schema = BeanIntrospectionTableSchema.create(EntityWithTtlOnDateField, context, cache)
+            BeanIntrospectionTableSchema.create(EntityWithTtlOnDateField, context, cache)
         then:
             thrown(IllegalArgumentException)
     }

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/schema/EntityWithCustomTtl.java
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/schema/EntityWithCustomTtl.java
@@ -1,3 +1,20 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2018-2025 Agorapulse.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.agorapulse.micronaut.amazon.awssdk.dynamodb.schema;
 
 import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.PartitionKey;

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/schema/EntityWithCustomTtl.java
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/schema/EntityWithCustomTtl.java
@@ -1,0 +1,34 @@
+package com.agorapulse.micronaut.amazon.awssdk.dynamodb.schema;
+
+import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.PartitionKey;
+import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.SortKey;
+import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.TimeToLive;
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected
+@TimeToLive(value = "365d", attributeName = "customTtl")
+public class EntityWithCustomTtl {
+
+    @PartitionKey
+    private Long id;
+
+    @SortKey
+    private Long sortKey;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getSortKey() {
+        return sortKey;
+    }
+
+    public void setSortKey(Long sortKey) {
+        this.sortKey = sortKey;
+    }
+
+}

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/schema/EntityWithTtl.java
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/schema/EntityWithTtl.java
@@ -1,3 +1,20 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2018-2025 Agorapulse.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.agorapulse.micronaut.amazon.awssdk.dynamodb.schema;
 
 import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.PartitionKey;

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/schema/EntityWithTtl.java
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/schema/EntityWithTtl.java
@@ -1,0 +1,34 @@
+package com.agorapulse.micronaut.amazon.awssdk.dynamodb.schema;
+
+import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.PartitionKey;
+import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.SortKey;
+import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.TimeToLive;
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected
+@TimeToLive("30d")
+public class EntityWithTtl {
+
+    @PartitionKey
+    private Long id;
+
+    @SortKey
+    private Long sortKey;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getSortKey() {
+        return sortKey;
+    }
+
+    public void setSortKey(Long sortKey) {
+        this.sortKey = sortKey;
+    }
+
+}

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/schema/EntityWithTtlOnDateField.java
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/schema/EntityWithTtlOnDateField.java
@@ -5,7 +5,6 @@ import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.SortKey;
 import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.TimeToLive;
 import io.micronaut.core.annotation.Introspected;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Introspected

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/schema/EntityWithTtlOnDateField.java
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/schema/EntityWithTtlOnDateField.java
@@ -1,0 +1,46 @@
+package com.agorapulse.micronaut.amazon.awssdk.dynamodb.schema;
+
+import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.PartitionKey;
+import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.SortKey;
+import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.TimeToLive;
+import io.micronaut.core.annotation.Introspected;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Introspected
+public class EntityWithTtlOnDateField {
+
+    @PartitionKey
+    private Long id;
+
+    @SortKey
+    private Long sortKey;
+
+    @TimeToLive(value = "6d")
+    private LocalDateTime created;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getSortKey() {
+        return sortKey;
+    }
+
+    public void setSortKey(Long sortKey) {
+        this.sortKey = sortKey;
+    }
+
+    public LocalDateTime getCreated() {
+        return created;
+    }
+
+    public void setCreated(LocalDateTime created) {
+        this.created = created;
+    }
+}

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/schema/EntityWithTtlOnDateField.java
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/schema/EntityWithTtlOnDateField.java
@@ -1,3 +1,20 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2018-2025 Agorapulse.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.agorapulse.micronaut.amazon.awssdk.dynamodb.schema;
 
 import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.PartitionKey;

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/schema/EntityWithTtlOnInstantField.java
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/schema/EntityWithTtlOnInstantField.java
@@ -1,3 +1,20 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2018-2025 Agorapulse.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.agorapulse.micronaut.amazon.awssdk.dynamodb.schema;
 
 import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.PartitionKey;

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/schema/EntityWithTtlOnInstantField.java
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/schema/EntityWithTtlOnInstantField.java
@@ -1,0 +1,45 @@
+package com.agorapulse.micronaut.amazon.awssdk.dynamodb.schema;
+
+import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.PartitionKey;
+import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.SortKey;
+import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.TimeToLive;
+import io.micronaut.core.annotation.Introspected;
+
+import java.time.Instant;
+
+@Introspected
+public class EntityWithTtlOnInstantField {
+
+    @PartitionKey
+    private Long id;
+
+    @SortKey
+    private Long sortKey;
+
+    @TimeToLive("45d")
+    private Instant created;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getSortKey() {
+        return sortKey;
+    }
+
+    public void setSortKey(Long sortKey) {
+        this.sortKey = sortKey;
+    }
+
+    public Instant getCreated() {
+        return created;
+    }
+
+    public void setCreated(Instant created) {
+        this.created = created;
+    }
+}

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/schema/EntityWithTtlOnLongField.java
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/schema/EntityWithTtlOnLongField.java
@@ -1,3 +1,20 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2018-2025 Agorapulse.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.agorapulse.micronaut.amazon.awssdk.dynamodb.schema;
 
 import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.PartitionKey;

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/schema/EntityWithTtlOnLongField.java
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/schema/EntityWithTtlOnLongField.java
@@ -1,0 +1,43 @@
+package com.agorapulse.micronaut.amazon.awssdk.dynamodb.schema;
+
+import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.PartitionKey;
+import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.SortKey;
+import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.TimeToLive;
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected
+public class EntityWithTtlOnLongField {
+
+    @PartitionKey
+    private Long id;
+
+    @SortKey
+    private Long sortKey;
+
+    @TimeToLive(value = "3d")
+    private Long created;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getSortKey() {
+        return sortKey;
+    }
+
+    public void setSortKey(Long sortKey) {
+        this.sortKey = sortKey;
+    }
+
+    public Long getCreated() {
+        return created;
+    }
+
+    public void setCreated(Long created) {
+        this.created = created;
+    }
+}

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/schema/EntityWithTtlOnStringField.java
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/schema/EntityWithTtlOnStringField.java
@@ -1,3 +1,20 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2018-2025 Agorapulse.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.agorapulse.micronaut.amazon.awssdk.dynamodb.schema;
 
 import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.PartitionKey;

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/schema/EntityWithTtlOnStringField.java
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/schema/EntityWithTtlOnStringField.java
@@ -1,0 +1,43 @@
+package com.agorapulse.micronaut.amazon.awssdk.dynamodb.schema;
+
+import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.PartitionKey;
+import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.SortKey;
+import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.TimeToLive;
+import io.micronaut.core.annotation.Introspected;
+
+@Introspected
+public class EntityWithTtlOnStringField {
+
+    @PartitionKey
+    private Long id;
+
+    @SortKey
+    private Long sortKey;
+
+    @TimeToLive(value = "17d", format = "yyyy-MM-dd'T'HH")
+    private String created;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getSortKey() {
+        return sortKey;
+    }
+
+    public void setSortKey(Long sortKey) {
+        this.sortKey = sortKey;
+    }
+
+    public String getCreated() {
+        return created;
+    }
+
+    public void setCreated(String created) {
+        this.created = created;
+    }
+}


### PR DESCRIPTION
New `@TimeToLive` annotation to be added on the entities to add TTL field to the payload on save or update.

```java
 import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.PartitionKey;
 import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.SortKey;
 import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.TimeToLive;
 import io.micronaut.core.annotation.Introspected;

 @Introspected
 @TimeToLive("30d")
 public class EntityWithTtl {

     @PartitionKey
     private Long id;

     @SortKey
     private Long sortKey;

     public Long getId() {
         return id;
     }

     public void setId(Long id) {
         this.id = id;
     }

     public Long getSortKey() {
         return sortKey;
     }

     public void setSortKey(Long sortKey) {
         this.sortKey = sortKey;
     }

 }
 ```