### PR TITLE
add collection support and blocking executor for QueueClientIntroduction

### DIFF
--- a/docs/guide/src/docs/asciidoc/sqs.adoc
+++ b/docs/guide/src/docs/asciidoc/sqs.adoc
@@ -94,7 +94,12 @@ include::{root-dir}/subprojects/micronaut-amazon-awssdk-sqs/src/test/groovy/com/
 <8> You can publish a string with custom delay and FIFO queue group
 <9> You can send multiple messages at once when the argument is `Publisher`
 <10> If the return type is also publisher type then **you need to subscribe to the publisher to actually send the messages**
-<11> You can delete published message using the message ID if the
+<11> You can delete published message using the message ID
+<12> You can send multiple messages at once when the argument is `List` and return a list of message IDs
+<13> You can send multiple string messages at once when the argument is `List` and return a list of message IDs
+<14> You can send multiple messages at once when the argument is an array and return a list of message IDs
+<15> You can send multiple string messages at once when the argument is an array and return a list of message IDs
+<16> You can send multiple messages at once and return void
 
 [source,java,indent=0,options="nowrap",role="secondary"]
 .Publishing String Records (AWS SDK 1.x)

--- a/subprojects/micronaut-amazon-awssdk-sqs/micronaut-amazon-awssdk-sqs.gradle
+++ b/subprojects/micronaut-amazon-awssdk-sqs/micronaut-amazon-awssdk-sqs.gradle
@@ -19,8 +19,9 @@ dependencies {
     annotationProcessor 'io.micronaut.validation:micronaut-validation-processor'
     api 'software.amazon.awssdk:sqs'
 
-   api project(':micronaut-amazon-awssdk-core')
+    api project(':micronaut-amazon-awssdk-core')
     implementation "space.jasan:groovy-closure-support:$closureSupportVersion"
+    implementation "io.projectreactor:reactor-core:$projectReactorVersion"
     implementation 'io.micronaut.validation:micronaut-validation'
     implementation 'io.micronaut:micronaut-jackson-databind'
     implementation 'io.micronaut.reactor:micronaut-reactor'

--- a/subprojects/micronaut-amazon-awssdk-sqs/src/main/java/com/agorapulse/micronaut/amazon/awssdk/sqs/QueueClientIntroduction.java
+++ b/subprojects/micronaut-amazon-awssdk-sqs/src/main/java/com/agorapulse/micronaut/amazon/awssdk/sqs/QueueClientIntroduction.java
@@ -32,20 +32,29 @@ import io.micronaut.core.async.publisher.Publishers;
 import io.micronaut.core.type.Argument;
 import io.micronaut.core.util.StringUtils;
 import io.micronaut.inject.qualifiers.Qualifiers;
+import io.micronaut.scheduling.LoomSupport;
+import jakarta.annotation.PreDestroy;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.QueueDoesNotExistException;
 
 import jakarta.inject.Singleton;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.function.Function;
 
 @Singleton
 @InterceptorBean(QueueClient.class)
 @Requires(classes = SqsClient.class)
-public class QueueClientIntroduction implements MethodInterceptor<Object, Object> {
+public class QueueClientIntroduction implements MethodInterceptor<Object, Object>, AutoCloseable {
 
     private static final String GROUP = "group";
     private static final String DELAY = "delay";
@@ -66,10 +75,19 @@ public class QueueClientIntroduction implements MethodInterceptor<Object, Object
 
     private final BeanContext beanContext;
     private final ObjectMapper objectMapper;
+    private final ExecutorService blockingExecutorService = LoomSupport.isSupported()
+        ? LoomSupport.newThreadPerTaskExecutor(LoomSupport.newVirtualThreadFactory("sqs-blocking-pool-"))
+        : Executors.newCachedThreadPool();
 
     public QueueClientIntroduction(BeanContext beanContext, ObjectMapper objectMapper) {
         this.beanContext = beanContext;
         this.objectMapper = objectMapper;
+    }
+
+    @Override
+    @PreDestroy
+    public void close() {
+        blockingExecutorService.shutdown();
     }
 
     @Override
@@ -153,16 +171,33 @@ public class QueueClientIntroduction implements MethodInterceptor<Object, Object
                      messageIdsPublisher = service.sendMessages(queueName, Flux.from((Publisher<?>) message).map(this::convertMessageToJson), delay, group);
                 }
 
-                if (context.getReturnType().asArgument().isVoid()) {
-                    Flux.from(messageIdsPublisher).subscribe();
-                    return null;
+                return unwrapIfRequired(messageIdsPublisher, context);
+            }
+
+            if (Iterable.class.isAssignableFrom(messageType)) {
+                Publisher<String> messageIdsPublisher;
+
+                Argument<?>[] typeParameters = queueArguments.message.getTypeParameters();
+                if (typeParameters.length > 0 && typeParameters[0].equalsType(Argument.STRING)) {
+                    messageIdsPublisher = service.sendMessages(queueName, Flux.fromIterable((Iterable<String>) message), delay, group);
+                } else {
+                    messageIdsPublisher = service.sendMessages(queueName, Flux.fromIterable((Iterable<?>) message).map(this::convertMessageToJson), delay, group);
                 }
 
-                if (Publishers.isConvertibleToPublisher(context.getReturnType().getType())) {
-                    return Publishers.convertPublisher(beanContext.getConversionService(), messageIdsPublisher, context.getReturnType().getType());
+                return unwrapIfRequired(messageIdsPublisher, context);
+            }
+
+            if (messageType.isArray()) {
+                Publisher<String> messageIdsPublisher;
+
+                Class<?> componentType = messageType.getComponentType();
+                if (String.class.equals(componentType)) {
+                    messageIdsPublisher = service.sendMessages(queueName, Flux.fromArray((String[]) message), delay, group);
+                } else {
+                    messageIdsPublisher = service.sendMessages(queueName, Flux.fromArray((Object[]) message).map(this::convertMessageToJson), delay, group);
                 }
 
-                return beanContext.getConversionService().convert(messageIdsPublisher, context.getReturnType().getType());
+                return unwrapIfRequired(messageIdsPublisher, context);
             }
 
             return sendJson(service, queueName, message, delay, group);
@@ -203,5 +238,42 @@ public class QueueClientIntroduction implements MethodInterceptor<Object, Object
         }
 
         return names;
+    }
+
+    private Object unwrapIfRequired(Publisher<String> publisher, MethodInvocationContext<Object, Object> context) {
+        Class<Object> type = context.getReturnType().getType();
+
+        if (void.class.isAssignableFrom(type) || Void.class.isAssignableFrom(type)) {
+            safeBlock(Flux.from(publisher).collectList());
+            return null;
+        }
+
+        if (Publishers.isConvertibleToPublisher(type)) {
+            return Publishers.convertPublisher(beanContext.getConversionService(), publisher, type);
+        }
+
+        if (type.isArray() || Iterable.class.isAssignableFrom(type)) {
+            List<String> result = safeBlock(Flux.from(publisher).collectList());
+            return beanContext.getConversionService().convert(result, type).orElse(result);
+        }
+
+        return beanContext.getConversionService().convert(publisher, type).orElse(null);
+    }
+
+    private <T> T safeBlock(Mono<T> mono) {
+        // fast track for blocking threads, we can call block directly
+        if (!Schedulers.isInNonBlockingThread()) {
+            return mono.block();
+        }
+
+        // for a non-blocking thread we need to move the blocking operation to a separate thread
+        try {
+            return CompletableFuture.supplyAsync(mono::block, blockingExecutorService).join();
+        } catch (CompletionException e) {
+            if (e.getCause() instanceof RuntimeException runtimeException) {
+                throw runtimeException;
+            }
+            throw e;
+        }
     }
 }

--- a/subprojects/micronaut-amazon-awssdk-sqs/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/sqs/DefaultClient.java
+++ b/subprojects/micronaut-amazon-awssdk-sqs/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/sqs/DefaultClient.java
@@ -21,6 +21,8 @@ import com.agorapulse.micronaut.amazon.awssdk.sqs.annotation.Queue;
 import com.agorapulse.micronaut.amazon.awssdk.sqs.annotation.QueueClient;
 import org.reactivestreams.Publisher;
 
+import java.util.List;
+
 @QueueClient                                                                            // <1>
 interface DefaultClient {
 
@@ -44,6 +46,16 @@ interface DefaultClient {
     Publisher<String> sendMessages(Publisher<Pogo> messages);                           // <10>
 
     void deleteMessage(String messageId);                                               // <11>
+
+    List<String> sendMessages(List<Pogo> messages);                                     // <12>
+
+    List<String> sendStringMessages(List<String> messages);                             // <13>
+
+    List<String> sendMessages(Pogo[] messages);                                         // <14>
+
+    List<String> sendStringMessages(String[] messages);                                 // <15>
+
+    void sendMessagesVoid(List<Pogo> messages);                                         // <16>
 
     String OTHER_QUEUE = "OtherQueue";
 }

--- a/subprojects/micronaut-amazon-awssdk-sqs/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/sqs/QueueClientCollectionTest.java
+++ b/subprojects/micronaut-amazon-awssdk-sqs/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/sqs/QueueClientCollectionTest.java
@@ -1,0 +1,120 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2018-2026 Agorapulse.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.agorapulse.micronaut.amazon.awssdk.sqs;
+
+import io.micronaut.context.annotation.Property;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.core.scheduler.Schedulers;
+
+import jakarta.inject.Inject;
+import java.util.List;
+import java.util.function.Predicate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@MicronautTest
+@Property(name = "aws.sqs.queue", value = QueueClientCollectionTest.TEST_QUEUE)
+class QueueClientCollectionTest {
+
+    static final String TEST_QUEUE = "TestQueueCollection";
+
+    private static final String MESSAGE = "Hello World";
+
+    @Inject
+    SimpleQueueService service;
+
+    @Inject
+    DefaultClient client;
+
+    private String testThreadName;
+
+    @BeforeEach
+    void setup() {
+        // simulate non-blocking thread to test the blocking executor pattern
+        testThreadName = Thread.currentThread().getName();
+        Schedulers.registerNonBlockingThreadPredicate((Predicate<Thread>) t -> t.getName().equals(testThreadName));
+
+        service.createQueue(TEST_QUEUE);
+    }
+
+    @AfterEach
+    void cleanup() {
+        Schedulers.resetNonBlockingThreadPredicate();
+        service.deleteQueue(TEST_QUEUE);
+    }
+
+    @Test
+    void canSendMultipleStringMessagesWhenListIsParameterAndReturnListOfIds() {
+        List<String> result = client.sendStringMessages(List.of(MESSAGE, MESSAGE, MESSAGE));
+
+        assertNotNull(result);
+        assertEquals(3, result.size());
+        result.forEach(Assertions::assertNotNull);
+    }
+
+    @Test
+    void canSendMultipleStringMessagesWhenArrayIsParameterAndReturnListOfIds() {
+        String[] messages = new String[]{MESSAGE, MESSAGE, MESSAGE};
+
+        List<String> result = client.sendStringMessages(messages);
+
+        assertNotNull(result);
+        assertEquals(3, result.size());
+        result.forEach(Assertions::assertNotNull);
+    }
+
+    @Test
+    void canSendMultipleMessagesWhenListIsParameterAndReturnListOfIds() {
+        Pogo pogo = new Pogo();
+        pogo.setFoo("bar");
+
+        List<String> result = client.sendMessages(List.of(pogo, pogo, pogo));
+
+        assertNotNull(result);
+        assertEquals(3, result.size());
+        result.forEach(Assertions::assertNotNull);
+    }
+
+    @Test
+    void canSendMultipleMessagesWhenArrayIsParameterAndReturnListOfIds() {
+        Pogo pogo = new Pogo();
+        pogo.setFoo("bar");
+        Pogo[] messages = new Pogo[]{pogo, pogo, pogo};
+
+        List<String> result = client.sendMessages(messages);
+
+        assertNotNull(result);
+        assertEquals(3, result.size());
+        result.forEach(Assertions::assertNotNull);
+    }
+
+    @Test
+    void canSendMultipleMessagesWhenListIsParameterAndReturnVoid() {
+        Pogo pogo = new Pogo();
+        pogo.setFoo("bar");
+
+        // should not throw any exception
+        client.sendMessagesVoid(List.of(pogo, pogo, pogo));
+    }
+
+}

--- a/subprojects/micronaut-amazon-awssdk-sqs/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/sqs/QueueClientSpec.groovy
+++ b/subprojects/micronaut-amazon-awssdk-sqs/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/sqs/QueueClientSpec.groovy
@@ -22,10 +22,7 @@ import io.micronaut.context.ApplicationContext
 import io.micronaut.inject.qualifiers.Qualifiers
 import org.reactivestreams.Publisher
 import reactor.core.publisher.Flux
-import reactor.core.scheduler.Schedulers
 import spock.lang.AutoCleanup
-
-import java.util.function.Predicate
 import spock.lang.Specification
 
 /**
@@ -53,10 +50,6 @@ class QueueClientSpec extends Specification {
     String marshalledPogo
 
     void setup() {
-        // simulate non-blocking thread to test the blocking executor pattern
-        String testThreadName = Thread.currentThread().getName()
-        Schedulers.registerNonBlockingThreadPredicate({ Thread t -> t.getName() == testThreadName } as Predicate<Thread>)
-
         context = ApplicationContext.builder().build()
 
         context.registerSingleton(SimpleQueueService, defaultService)
@@ -65,10 +58,6 @@ class QueueClientSpec extends Specification {
         context.start()
 
         marshalledPogo = context.getBean(ObjectMapper).writeValueAsString(POGO)
-    }
-
-    void cleanup() {
-        Schedulers.resetNonBlockingThreadPredicate()
     }
 
     void 'can send message to other than default queue potentionally altering the group'() {
@@ -209,75 +198,6 @@ class QueueClientSpec extends Specification {
             id == ID
 
             1 * defaultService.sendMessage(SomeClient.SOME_QUEUE, marshalledPogo, DELAY, null) >> ID
-    }
-
-    void 'can send multiple messages when list is a parameter and return list of ids'() {
-        given:
-            List<String> ids = [ID + 1, ID + 2, ID + 3]
-            DefaultClient client = context.getBean(DefaultClient)
-
-        when:
-            List<String> result = client.sendMessages([POGO, POGO, POGO])
-
-        then:
-            result == ids
-
-            1 * defaultService.sendMessages(DEFAULT_QUEUE_NAME, _ as Publisher, 0, null) >> Flux.just(ID + 1, ID + 2, ID + 3)
-    }
-
-    void 'can send multiple string messages when list is a parameter and return list of ids'() {
-        given:
-            List<String> ids = [ID + 1, ID + 2, ID + 3]
-            DefaultClient client = context.getBean(DefaultClient)
-
-        when:
-            List<String> result = client.sendStringMessages([MESSAGE, MESSAGE, MESSAGE])
-
-        then:
-            result == ids
-
-            1 * defaultService.sendMessages(DEFAULT_QUEUE_NAME, _ as Publisher, 0, null) >> Flux.just(ID + 1, ID + 2, ID + 3)
-    }
-
-    void 'can send multiple messages when array is a parameter and return list of ids'() {
-        given:
-            List<String> ids = [ID + 1, ID + 2, ID + 3]
-            DefaultClient client = context.getBean(DefaultClient)
-            Pogo[] messages = [POGO, POGO, POGO] as Pogo[]
-
-        when:
-            List<String> result = client.sendMessages(messages)
-
-        then:
-            result == ids
-
-            1 * defaultService.sendMessages(DEFAULT_QUEUE_NAME, _ as Publisher, 0, null) >> Flux.just(ID + 1, ID + 2, ID + 3)
-    }
-
-    void 'can send multiple string messages when array is a parameter and return list of ids'() {
-        given:
-            List<String> ids = [ID + 1, ID + 2, ID + 3]
-            DefaultClient client = context.getBean(DefaultClient)
-            String[] messages = [MESSAGE, MESSAGE, MESSAGE] as String[]
-
-        when:
-            List<String> result = client.sendStringMessages(messages)
-
-        then:
-            result == ids
-
-            1 * defaultService.sendMessages(DEFAULT_QUEUE_NAME, _ as Publisher, 0, null) >> Flux.just(ID + 1, ID + 2, ID + 3)
-    }
-
-    void 'can send multiple messages when list is a parameter and return void'() {
-        given:
-            DefaultClient client = context.getBean(DefaultClient)
-
-        when:
-            client.sendMessagesVoid([POGO, POGO, POGO])
-
-        then:
-            1 * defaultService.sendMessages(DEFAULT_QUEUE_NAME, _ as Publisher, 0, null) >> Flux.just(ID + 1, ID + 2, ID + 3)
     }
 
 }

--- a/subprojects/micronaut-amazon-awssdk-sqs/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/sqs/QueueClientSpec.groovy
+++ b/subprojects/micronaut-amazon-awssdk-sqs/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/sqs/QueueClientSpec.groovy
@@ -22,6 +22,7 @@ import io.micronaut.context.ApplicationContext
 import io.micronaut.inject.qualifiers.Qualifiers
 import org.reactivestreams.Publisher
 import reactor.core.publisher.Flux
+import reactor.core.scheduler.Schedulers
 import spock.lang.AutoCleanup
 import spock.lang.Specification
 
@@ -50,6 +51,10 @@ class QueueClientSpec extends Specification {
     String marshalledPogo
 
     void setup() {
+        // simulate non-blocking thread to test the blocking executor pattern
+        String testThreadName = Thread.currentThread().getName()
+        Schedulers.registerNonBlockingThreadPredicate { t -> t.getName() == testThreadName }
+
         context = ApplicationContext.builder().build()
 
         context.registerSingleton(SimpleQueueService, defaultService)
@@ -58,6 +63,10 @@ class QueueClientSpec extends Specification {
         context.start()
 
         marshalledPogo = context.getBean(ObjectMapper).writeValueAsString(POGO)
+    }
+
+    void cleanup() {
+        Schedulers.resetNonBlockingThreadPredicate()
     }
 
     void 'can send message to other than default queue potentionally altering the group'() {
@@ -198,6 +207,75 @@ class QueueClientSpec extends Specification {
             id == ID
 
             1 * defaultService.sendMessage(SomeClient.SOME_QUEUE, marshalledPogo, DELAY, null) >> ID
+    }
+
+    void 'can send multiple messages when list is a parameter and return list of ids'() {
+        given:
+            List<String> ids = [ID + 1, ID + 2, ID + 3]
+            DefaultClient client = context.getBean(DefaultClient)
+
+        when:
+            List<String> result = client.sendMessages([POGO, POGO, POGO])
+
+        then:
+            result == ids
+
+            1 * defaultService.sendMessages(DEFAULT_QUEUE_NAME, _ as Publisher, 0, null) >> Flux.just(ID + 1, ID + 2, ID + 3)
+    }
+
+    void 'can send multiple string messages when list is a parameter and return list of ids'() {
+        given:
+            List<String> ids = [ID + 1, ID + 2, ID + 3]
+            DefaultClient client = context.getBean(DefaultClient)
+
+        when:
+            List<String> result = client.sendStringMessages([MESSAGE, MESSAGE, MESSAGE])
+
+        then:
+            result == ids
+
+            1 * defaultService.sendMessages(DEFAULT_QUEUE_NAME, _ as Publisher, 0, null) >> Flux.just(ID + 1, ID + 2, ID + 3)
+    }
+
+    void 'can send multiple messages when array is a parameter and return list of ids'() {
+        given:
+            List<String> ids = [ID + 1, ID + 2, ID + 3]
+            DefaultClient client = context.getBean(DefaultClient)
+            Pogo[] messages = [POGO, POGO, POGO] as Pogo[]
+
+        when:
+            List<String> result = client.sendMessages(messages)
+
+        then:
+            result == ids
+
+            1 * defaultService.sendMessages(DEFAULT_QUEUE_NAME, _ as Publisher, 0, null) >> Flux.just(ID + 1, ID + 2, ID + 3)
+    }
+
+    void 'can send multiple string messages when array is a parameter and return list of ids'() {
+        given:
+            List<String> ids = [ID + 1, ID + 2, ID + 3]
+            DefaultClient client = context.getBean(DefaultClient)
+            String[] messages = [MESSAGE, MESSAGE, MESSAGE] as String[]
+
+        when:
+            List<String> result = client.sendStringMessages(messages)
+
+        then:
+            result == ids
+
+            1 * defaultService.sendMessages(DEFAULT_QUEUE_NAME, _ as Publisher, 0, null) >> Flux.just(ID + 1, ID + 2, ID + 3)
+    }
+
+    void 'can send multiple messages when list is a parameter and return void'() {
+        given:
+            DefaultClient client = context.getBean(DefaultClient)
+
+        when:
+            client.sendMessagesVoid([POGO, POGO, POGO])
+
+        then:
+            1 * defaultService.sendMessages(DEFAULT_QUEUE_NAME, _ as Publisher, 0, null) >> Flux.just(ID + 1, ID + 2, ID + 3)
     }
 
 }

--- a/subprojects/micronaut-amazon-awssdk-sqs/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/sqs/QueueClientSpec.groovy
+++ b/subprojects/micronaut-amazon-awssdk-sqs/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/sqs/QueueClientSpec.groovy
@@ -24,6 +24,8 @@ import org.reactivestreams.Publisher
 import reactor.core.publisher.Flux
 import reactor.core.scheduler.Schedulers
 import spock.lang.AutoCleanup
+
+import java.util.function.Predicate
 import spock.lang.Specification
 
 /**
@@ -53,7 +55,7 @@ class QueueClientSpec extends Specification {
     void setup() {
         // simulate non-blocking thread to test the blocking executor pattern
         String testThreadName = Thread.currentThread().getName()
-        Schedulers.registerNonBlockingThreadPredicate { t -> t.getName() == testThreadName }
+        Schedulers.registerNonBlockingThreadPredicate({ Thread t -> t.getName() == testThreadName } as Predicate<Thread>)
 
         context = ApplicationContext.builder().build()
 


### PR DESCRIPTION
- Add support for Iterable and array as message input parameters
- Add support for returning List<String> of message IDs for batch operations
- Implement safeBlock pattern using blocking executor service to handle blocking operations on non-blocking threads (same pattern as DynamoDB)
- Use LoomSupport for virtual threads when available, fallback to cached thread pool
- Implement AutoCloseable with @PreDestroy for proper executor shutdown
- Add tests for collection input/output with non-blocking thread simulation