### PR TITLE
feat: add GCP Workload Identity Federation support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -45,6 +45,9 @@ jackson.datatype.version=2.9.7
 # kinesis client version
 kinesisClientV2Version=2.7.0
 
+# google auth library version
+googleAuthVersion=1.23.0
+
 # project reactor version
 projectReactorVersion = 3.8.2
 

--- a/platforms/micronaut-aws-sdk-dependencies/micronaut-aws-sdk-dependencies.gradle
+++ b/platforms/micronaut-aws-sdk-dependencies/micronaut-aws-sdk-dependencies.gradle
@@ -45,6 +45,9 @@ dependencies {
 
         api group: 'com.amazonaws', name: 'aws-lambda-java-events', version: awsLambdaEventsVersion
         api group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: project['jackson.datatype.version']
+
+        // GCP dependencies for Workload Identity Federation
+        api 'com.google.auth:google-auth-library-oauth2-http:1.23.0'
     }
 }
 

--- a/platforms/micronaut-aws-sdk-dependencies/micronaut-aws-sdk-dependencies.gradle
+++ b/platforms/micronaut-aws-sdk-dependencies/micronaut-aws-sdk-dependencies.gradle
@@ -47,7 +47,7 @@ dependencies {
         api group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: project['jackson.datatype.version']
 
         // GCP dependencies for Workload Identity Federation
-        api 'com.google.auth:google-auth-library-oauth2-http:1.23.0'
+        api "com.google.auth:google-auth-library-oauth2-http:$googleAuthVersion"
     }
 }
 

--- a/subprojects/micronaut-amazon-awssdk-gcp/micronaut-amazon-awssdk-gcp.gradle
+++ b/subprojects/micronaut-amazon-awssdk-gcp/micronaut-amazon-awssdk-gcp.gradle
@@ -1,0 +1,25 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2018-2026 Agorapulse.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+dependencies {
+    api project(':micronaut-amazon-awssdk-core')
+    
+    // GCP Auth library for Workload Identity Federation
+    api 'com.google.auth:google-auth-library-oauth2-http:1.23.0'
+    
+    testImplementation 'org.testcontainers:localstack'
+}

--- a/subprojects/micronaut-amazon-awssdk-gcp/micronaut-amazon-awssdk-gcp.gradle
+++ b/subprojects/micronaut-amazon-awssdk-gcp/micronaut-amazon-awssdk-gcp.gradle
@@ -19,7 +19,7 @@ dependencies {
     api project(':micronaut-amazon-awssdk-core')
     
     // GCP Auth library for Workload Identity Federation
-    api 'com.google.auth:google-auth-library-oauth2-http:1.23.0'
+    api "com.google.auth:google-auth-library-oauth2-http:$googleAuthVersion"
     
     testImplementation 'org.testcontainers:localstack'
 }

--- a/subprojects/micronaut-amazon-awssdk-gcp/src/main/java/com/agorapulse/micronaut/amazon/awssdk/gcp/AwsSecurityCredentialsSupplierBean.java
+++ b/subprojects/micronaut-amazon-awssdk-gcp/src/main/java/com/agorapulse/micronaut/amazon/awssdk/gcp/AwsSecurityCredentialsSupplierBean.java
@@ -1,0 +1,89 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2018-2026 Agorapulse.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.agorapulse.micronaut.amazon.awssdk.gcp;
+
+import com.google.auth.oauth2.AwsSecurityCredentials;
+import com.google.auth.oauth2.AwsSecurityCredentialsSupplier;
+import com.google.auth.oauth2.ExternalAccountSupplierContext;
+import jakarta.inject.Singleton;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.regions.providers.AwsRegionProvider;
+
+/**
+ * AWS Security Credentials Supplier for GCP Workload Identity Federation.
+ * <p>
+ * This bean bridges AWS credentials to GCP's Workload Identity Federation, allowing
+ * GCP services (like Vertex AI) to authenticate using AWS credentials.
+ * <p>
+ * Uses the standard AWS SDK credentials provider which works across all AWS environments:
+ * <ul>
+ *   <li>ECS (via container credentials)</li>
+ *   <li>Lambda (via environment credentials)</li>
+ *   <li>EC2 (via instance metadata)</li>
+ *   <li>Local development (via profiles or environment variables)</li>
+ * </ul>
+ *
+ * @see com.google.auth.oauth2.AwsCredentials
+ */
+@Singleton
+public class AwsSecurityCredentialsSupplierBean implements AwsSecurityCredentialsSupplier {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AwsSecurityCredentialsSupplierBean.class);
+
+    private final transient AwsCredentialsProvider credentialsProvider;
+    private final transient AwsRegionProvider regionProvider;
+
+    public AwsSecurityCredentialsSupplierBean(
+            AwsCredentialsProvider credentialsProvider,
+            AwsRegionProvider regionProvider
+    ) {
+        this.credentialsProvider = credentialsProvider;
+        this.regionProvider = regionProvider;
+    }
+
+    @Override
+    public AwsSecurityCredentials getCredentials(ExternalAccountSupplierContext context) {
+        LOG.debug("Fetching AWS credentials via SDK credentials provider for GCP WIF");
+        
+        var creds = credentialsProvider.resolveCredentials();
+        
+        if (creds instanceof AwsSessionCredentials sessionCreds) {
+            LOG.debug("Using session credentials with token");
+            return new AwsSecurityCredentials(
+                    sessionCreds.accessKeyId(),
+                    sessionCreds.secretAccessKey(),
+                    sessionCreds.sessionToken()
+            );
+        }
+        
+        LOG.debug("Using basic credentials without token");
+        return new AwsSecurityCredentials(
+                creds.accessKeyId(),
+                creds.secretAccessKey(),
+                null
+        );
+    }
+
+    @Override
+    public String getRegion(ExternalAccountSupplierContext context) {
+        return regionProvider.getRegion().id();
+    }
+}

--- a/subprojects/micronaut-amazon-awssdk-gcp/src/main/java/com/agorapulse/micronaut/amazon/awssdk/gcp/GcpCredentialsFactory.java
+++ b/subprojects/micronaut-amazon-awssdk-gcp/src/main/java/com/agorapulse/micronaut/amazon/awssdk/gcp/GcpCredentialsFactory.java
@@ -1,0 +1,94 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2018-2026 Agorapulse.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.agorapulse.micronaut.amazon.awssdk.gcp;
+
+import com.google.auth.oauth2.AwsCredentials;
+import com.google.auth.oauth2.GoogleCredentials;
+import io.micronaut.context.annotation.Bean;
+import io.micronaut.context.annotation.Factory;
+import io.micronaut.context.annotation.Requires;
+import jakarta.inject.Singleton;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Factory for creating GCP credentials using AWS Workload Identity Federation.
+ * <p>
+ * This factory creates {@link GoogleCredentials} that use AWS credentials
+ * to authenticate with GCP services via Workload Identity Federation.
+ * <p>
+ * The credentials are only created when:
+ * <ul>
+ *   <li>The configuration is enabled ({@code gcp.workload-identity.enabled=true})</li>
+ *   <li>All required properties are configured (project-number, pool-id, provider-id, service-account-email)</li>
+ * </ul>
+ */
+@Factory
+public class GcpCredentialsFactory {
+
+    private static final Logger LOG = LoggerFactory.getLogger(GcpCredentialsFactory.class);
+
+    /**
+     * Creates GCP credentials using AWS Workload Identity Federation.
+     *
+     * @param configuration the WIF configuration
+     * @param credentialsSupplier the AWS credentials supplier
+     * @return GoogleCredentials configured for AWS WIF
+     */
+    @Bean
+    @Singleton
+    @Requires(beans = {GcpWorkloadIdentityConfiguration.class, AwsSecurityCredentialsSupplierBean.class})
+    @Requires(property = "gcp.workload-identity.enabled", value = "true", defaultValue = "true")
+    @Requires(property = "gcp.workload-identity.project-number")
+    @Requires(property = "gcp.workload-identity.pool-id")
+    @Requires(property = "gcp.workload-identity.provider-id")
+    @Requires(property = "gcp.workload-identity.service-account-email")
+    public GoogleCredentials gcpCredentials(
+            GcpWorkloadIdentityConfiguration configuration,
+            AwsSecurityCredentialsSupplierBean credentialsSupplier
+    ) {
+        LOG.info("Creating GCP credentials with AWS Workload Identity Federation");
+        LOG.debug("Project number: {}, Pool: {}, Provider: {}",
+                configuration.getProjectNumber(),
+                configuration.getPoolId(),
+                configuration.getProviderId());
+
+        String audience = String.format(
+                "//iam.googleapis.com/projects/%s/locations/global/workloadIdentityPools/%s/providers/%s",
+                configuration.getProjectNumber(),
+                configuration.getPoolId(),
+                configuration.getProviderId()
+        );
+
+        String serviceAccountImpersonationUrl = String.format(
+                "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s:generateAccessToken",
+                configuration.getServiceAccountEmail()
+        );
+
+        LOG.debug("Audience: {}", audience);
+        LOG.debug("Service account impersonation URL: {}", serviceAccountImpersonationUrl);
+
+        return AwsCredentials.newBuilder()
+                .setAwsSecurityCredentialsSupplier(credentialsSupplier)
+                .setAudience(audience)
+                .setSubjectTokenType("urn:ietf:params:aws:token-type:aws4_request")
+                .setTokenUrl("https://sts.googleapis.com/v1/token")
+                .setServiceAccountImpersonationUrl(serviceAccountImpersonationUrl)
+                .build();
+    }
+}

--- a/subprojects/micronaut-amazon-awssdk-gcp/src/main/java/com/agorapulse/micronaut/amazon/awssdk/gcp/GcpCredentialsFactory.java
+++ b/subprojects/micronaut-amazon-awssdk-gcp/src/main/java/com/agorapulse/micronaut/amazon/awssdk/gcp/GcpCredentialsFactory.java
@@ -32,12 +32,12 @@ import org.slf4j.LoggerFactory;
  * This factory creates {@link GoogleCredentials} that use AWS credentials
  * to authenticate with GCP services via Workload Identity Federation.
  * <p>
- * The credentials are only created when all required environment variables are set:
+ * The credentials are only created when all required properties are set:
  * <ul>
- *   <li>{@code GCP_PROJECT_NUMBER}</li>
- *   <li>{@code GCP_WORKLOAD_POOL}</li>
- *   <li>{@code GCP_WORKLOAD_PROVIDER}</li>
- *   <li>{@code GCP_SERVICE_ACCOUNT}</li>
+ *   <li>{@code gcp.project-number} (or env: {@code GCP_PROJECT_NUMBER})</li>
+ *   <li>{@code gcp.workload-pool} (or env: {@code GCP_WORKLOAD_POOL})</li>
+ *   <li>{@code gcp.workload-provider} (or env: {@code GCP_WORKLOAD_PROVIDER})</li>
+ *   <li>{@code gcp.service-account} (or env: {@code GCP_SERVICE_ACCOUNT})</li>
  * </ul>
  */
 @Factory
@@ -55,10 +55,10 @@ public class GcpCredentialsFactory {
     @Bean
     @Singleton
     @Requires(beans = {GcpWorkloadIdentityConfiguration.class, AwsSecurityCredentialsSupplierBean.class})
-    @Requires(property = "GCP_PROJECT_NUMBER")
-    @Requires(property = "GCP_WORKLOAD_POOL")
-    @Requires(property = "GCP_WORKLOAD_PROVIDER")
-    @Requires(property = "GCP_SERVICE_ACCOUNT")
+    @Requires(property = "gcp.project-number")
+    @Requires(property = "gcp.workload-pool")
+    @Requires(property = "gcp.workload-provider")
+    @Requires(property = "gcp.service-account")
     public GoogleCredentials gcpCredentials(
             GcpWorkloadIdentityConfiguration configuration,
             AwsSecurityCredentialsSupplierBean credentialsSupplier

--- a/subprojects/micronaut-amazon-awssdk-gcp/src/main/java/com/agorapulse/micronaut/amazon/awssdk/gcp/GcpCredentialsFactory.java
+++ b/subprojects/micronaut-amazon-awssdk-gcp/src/main/java/com/agorapulse/micronaut/amazon/awssdk/gcp/GcpCredentialsFactory.java
@@ -32,10 +32,12 @@ import org.slf4j.LoggerFactory;
  * This factory creates {@link GoogleCredentials} that use AWS credentials
  * to authenticate with GCP services via Workload Identity Federation.
  * <p>
- * The credentials are only created when:
+ * The credentials are only created when all required environment variables are set:
  * <ul>
- *   <li>The configuration is enabled ({@code gcp.workload-identity.enabled=true})</li>
- *   <li>All required properties are configured (project-number, pool-id, provider-id, service-account-email)</li>
+ *   <li>{@code GCP_PROJECT_NUMBER}</li>
+ *   <li>{@code GCP_WORKLOAD_POOL}</li>
+ *   <li>{@code GCP_WORKLOAD_PROVIDER}</li>
+ *   <li>{@code GCP_SERVICE_ACCOUNT}</li>
  * </ul>
  */
 @Factory
@@ -53,11 +55,10 @@ public class GcpCredentialsFactory {
     @Bean
     @Singleton
     @Requires(beans = {GcpWorkloadIdentityConfiguration.class, AwsSecurityCredentialsSupplierBean.class})
-    @Requires(property = "gcp.workload-identity.enabled", value = "true", defaultValue = "true")
-    @Requires(property = "gcp.workload-identity.project-number")
-    @Requires(property = "gcp.workload-identity.pool-id")
-    @Requires(property = "gcp.workload-identity.provider-id")
-    @Requires(property = "gcp.workload-identity.service-account-email")
+    @Requires(property = "GCP_PROJECT_NUMBER")
+    @Requires(property = "GCP_WORKLOAD_POOL")
+    @Requires(property = "GCP_WORKLOAD_PROVIDER")
+    @Requires(property = "GCP_SERVICE_ACCOUNT")
     public GoogleCredentials gcpCredentials(
             GcpWorkloadIdentityConfiguration configuration,
             AwsSecurityCredentialsSupplierBean credentialsSupplier
@@ -65,19 +66,19 @@ public class GcpCredentialsFactory {
         LOG.info("Creating GCP credentials with AWS Workload Identity Federation");
         LOG.debug("Project number: {}, Pool: {}, Provider: {}",
                 configuration.getProjectNumber(),
-                configuration.getPoolId(),
-                configuration.getProviderId());
+                configuration.getWorkloadPool(),
+                configuration.getWorkloadProvider());
 
         String audience = String.format(
                 "//iam.googleapis.com/projects/%s/locations/global/workloadIdentityPools/%s/providers/%s",
                 configuration.getProjectNumber(),
-                configuration.getPoolId(),
-                configuration.getProviderId()
+                configuration.getWorkloadPool(),
+                configuration.getWorkloadProvider()
         );
 
         String serviceAccountImpersonationUrl = String.format(
                 "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s:generateAccessToken",
-                configuration.getServiceAccountEmail()
+                configuration.getServiceAccount()
         );
 
         LOG.debug("Audience: {}", audience);

--- a/subprojects/micronaut-amazon-awssdk-gcp/src/main/java/com/agorapulse/micronaut/amazon/awssdk/gcp/GcpWorkloadIdentityConfiguration.java
+++ b/subprojects/micronaut-amazon-awssdk-gcp/src/main/java/com/agorapulse/micronaut/amazon/awssdk/gcp/GcpWorkloadIdentityConfiguration.java
@@ -1,0 +1,127 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2018-2026 Agorapulse.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.agorapulse.micronaut.amazon.awssdk.gcp;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+
+/**
+ * Configuration for GCP Workload Identity Federation with AWS.
+ * <p>
+ * Configure these properties to enable automatic creation of GCP credentials
+ * using AWS credentials via Workload Identity Federation.
+ * <p>
+ * Example configuration:
+ * <pre>
+ * gcp:
+ *   workload-identity:
+ *     enabled: true
+ *     project-number: "123456789012"
+ *     pool-id: "aws-pool"
+ *     provider-id: "aws-provider"
+ *     service-account-email: "my-sa@project.iam.gserviceaccount.com"
+ * </pre>
+ */
+@ConfigurationProperties("gcp.workload-identity")
+public class GcpWorkloadIdentityConfiguration {
+
+    private boolean enabled = true;
+    private String projectNumber;
+    private String poolId;
+    private String providerId;
+    private String serviceAccountEmail;
+
+    /**
+     * @return whether GCP Workload Identity Federation is enabled
+     */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * @param enabled whether GCP Workload Identity Federation is enabled
+     */
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    /**
+     * @return the GCP project number (not project ID)
+     */
+    public String getProjectNumber() {
+        return projectNumber;
+    }
+
+    /**
+     * @param projectNumber the GCP project number (not project ID)
+     */
+    public void setProjectNumber(String projectNumber) {
+        this.projectNumber = projectNumber;
+    }
+
+    /**
+     * @return the Workload Identity Pool ID
+     */
+    public String getPoolId() {
+        return poolId;
+    }
+
+    /**
+     * @param poolId the Workload Identity Pool ID
+     */
+    public void setPoolId(String poolId) {
+        this.poolId = poolId;
+    }
+
+    /**
+     * @return the Workload Identity Provider ID
+     */
+    public String getProviderId() {
+        return providerId;
+    }
+
+    /**
+     * @param providerId the Workload Identity Provider ID
+     */
+    public void setProviderId(String providerId) {
+        this.providerId = providerId;
+    }
+
+    /**
+     * @return the GCP service account email to impersonate
+     */
+    public String getServiceAccountEmail() {
+        return serviceAccountEmail;
+    }
+
+    /**
+     * @param serviceAccountEmail the GCP service account email to impersonate
+     */
+    public void setServiceAccountEmail(String serviceAccountEmail) {
+        this.serviceAccountEmail = serviceAccountEmail;
+    }
+
+    /**
+     * @return true if all required properties are configured
+     */
+    public boolean isFullyConfigured() {
+        return projectNumber != null && !projectNumber.isEmpty()
+                && poolId != null && !poolId.isEmpty()
+                && providerId != null && !providerId.isEmpty()
+                && serviceAccountEmail != null && !serviceAccountEmail.isEmpty();
+    }
+}

--- a/subprojects/micronaut-amazon-awssdk-gcp/src/main/java/com/agorapulse/micronaut/amazon/awssdk/gcp/GcpWorkloadIdentityConfiguration.java
+++ b/subprojects/micronaut-amazon-awssdk-gcp/src/main/java/com/agorapulse/micronaut/amazon/awssdk/gcp/GcpWorkloadIdentityConfiguration.java
@@ -17,45 +17,48 @@
  */
 package com.agorapulse.micronaut.amazon.awssdk.gcp;
 
-import io.micronaut.context.annotation.Value;
-import jakarta.inject.Singleton;
+import io.micronaut.context.annotation.ConfigurationProperties;
 
 /**
  * Configuration for GCP Workload Identity Federation with AWS.
  * <p>
- * Uses the same environment variables as typically configured in ECS task definitions:
+ * Can be configured via environment variables (Micronaut auto-converts):
  * <ul>
- *   <li>{@code GCP_PROJECT_NUMBER} - The GCP project number (not project ID)</li>
- *   <li>{@code GCP_WORKLOAD_POOL} - The Workload Identity Pool ID</li>
- *   <li>{@code GCP_WORKLOAD_PROVIDER} - The Workload Identity Provider ID</li>
- *   <li>{@code GCP_SERVICE_ACCOUNT} - The GCP service account email to impersonate</li>
+ *   <li>{@code GCP_PROJECT_NUMBER} → {@code gcp.project-number}</li>
+ *   <li>{@code GCP_WORKLOAD_POOL} → {@code gcp.workload-pool}</li>
+ *   <li>{@code GCP_WORKLOAD_PROVIDER} → {@code gcp.workload-provider}</li>
+ *   <li>{@code GCP_SERVICE_ACCOUNT} → {@code gcp.service-account}</li>
  * </ul>
+ * <p>
+ * Or via application.yml:
+ * <pre>
+ * gcp:
+ *   project-number: "123456789012"
+ *   workload-pool: "aws-pool"
+ *   workload-provider: "aws-provider"
+ *   service-account: "my-sa@project.iam.gserviceaccount.com"
+ * </pre>
  */
-@Singleton
+@ConfigurationProperties("gcp")
 public class GcpWorkloadIdentityConfiguration {
 
-    private final String projectNumber;
-    private final String workloadPool;
-    private final String workloadProvider;
-    private final String serviceAccount;
-
-    public GcpWorkloadIdentityConfiguration(
-            @Value("${GCP_PROJECT_NUMBER:}") String projectNumber,
-            @Value("${GCP_WORKLOAD_POOL:}") String workloadPool,
-            @Value("${GCP_WORKLOAD_PROVIDER:}") String workloadProvider,
-            @Value("${GCP_SERVICE_ACCOUNT:}") String serviceAccount
-    ) {
-        this.projectNumber = projectNumber;
-        this.workloadPool = workloadPool;
-        this.workloadProvider = workloadProvider;
-        this.serviceAccount = serviceAccount;
-    }
+    private String projectNumber;
+    private String workloadPool;
+    private String workloadProvider;
+    private String serviceAccount;
 
     /**
      * @return the GCP project number (not project ID)
      */
     public String getProjectNumber() {
         return projectNumber;
+    }
+
+    /**
+     * @param projectNumber the GCP project number (not project ID)
+     */
+    public void setProjectNumber(String projectNumber) {
+        this.projectNumber = projectNumber;
     }
 
     /**
@@ -66,6 +69,13 @@ public class GcpWorkloadIdentityConfiguration {
     }
 
     /**
+     * @param workloadPool the Workload Identity Pool ID
+     */
+    public void setWorkloadPool(String workloadPool) {
+        this.workloadPool = workloadPool;
+    }
+
+    /**
      * @return the Workload Identity Provider ID
      */
     public String getWorkloadProvider() {
@@ -73,10 +83,24 @@ public class GcpWorkloadIdentityConfiguration {
     }
 
     /**
+     * @param workloadProvider the Workload Identity Provider ID
+     */
+    public void setWorkloadProvider(String workloadProvider) {
+        this.workloadProvider = workloadProvider;
+    }
+
+    /**
      * @return the GCP service account email to impersonate
      */
     public String getServiceAccount() {
         return serviceAccount;
+    }
+
+    /**
+     * @param serviceAccount the GCP service account email to impersonate
+     */
+    public void setServiceAccount(String serviceAccount) {
+        this.serviceAccount = serviceAccount;
     }
 
     /**

--- a/subprojects/micronaut-amazon-awssdk-gcp/src/main/java/com/agorapulse/micronaut/amazon/awssdk/gcp/GcpWorkloadIdentityConfiguration.java
+++ b/subprojects/micronaut-amazon-awssdk-gcp/src/main/java/com/agorapulse/micronaut/amazon/awssdk/gcp/GcpWorkloadIdentityConfiguration.java
@@ -17,46 +17,38 @@
  */
 package com.agorapulse.micronaut.amazon.awssdk.gcp;
 
-import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.context.annotation.Value;
+import jakarta.inject.Singleton;
 
 /**
  * Configuration for GCP Workload Identity Federation with AWS.
  * <p>
- * Configure these properties to enable automatic creation of GCP credentials
- * using AWS credentials via Workload Identity Federation.
- * <p>
- * Example configuration:
- * <pre>
- * gcp:
- *   workload-identity:
- *     enabled: true
- *     project-number: "123456789012"
- *     pool-id: "aws-pool"
- *     provider-id: "aws-provider"
- *     service-account-email: "my-sa@project.iam.gserviceaccount.com"
- * </pre>
+ * Uses the same environment variables as typically configured in ECS task definitions:
+ * <ul>
+ *   <li>{@code GCP_PROJECT_NUMBER} - The GCP project number (not project ID)</li>
+ *   <li>{@code GCP_WORKLOAD_POOL} - The Workload Identity Pool ID</li>
+ *   <li>{@code GCP_WORKLOAD_PROVIDER} - The Workload Identity Provider ID</li>
+ *   <li>{@code GCP_SERVICE_ACCOUNT} - The GCP service account email to impersonate</li>
+ * </ul>
  */
-@ConfigurationProperties("gcp.workload-identity")
+@Singleton
 public class GcpWorkloadIdentityConfiguration {
 
-    private boolean enabled = true;
-    private String projectNumber;
-    private String poolId;
-    private String providerId;
-    private String serviceAccountEmail;
+    private final String projectNumber;
+    private final String workloadPool;
+    private final String workloadProvider;
+    private final String serviceAccount;
 
-    /**
-     * @return whether GCP Workload Identity Federation is enabled
-     */
-    public boolean isEnabled() {
-        return enabled;
-    }
-
-    /**
-     * @param enabled whether GCP Workload Identity Federation is enabled
-     */
-    public void setEnabled(boolean enabled) {
-        this.enabled = enabled;
+    public GcpWorkloadIdentityConfiguration(
+            @Value("${GCP_PROJECT_NUMBER:}") String projectNumber,
+            @Value("${GCP_WORKLOAD_POOL:}") String workloadPool,
+            @Value("${GCP_WORKLOAD_PROVIDER:}") String workloadProvider,
+            @Value("${GCP_SERVICE_ACCOUNT:}") String serviceAccount
+    ) {
+        this.projectNumber = projectNumber;
+        this.workloadPool = workloadPool;
+        this.workloadProvider = workloadProvider;
+        this.serviceAccount = serviceAccount;
     }
 
     /**
@@ -67,61 +59,37 @@ public class GcpWorkloadIdentityConfiguration {
     }
 
     /**
-     * @param projectNumber the GCP project number (not project ID)
-     */
-    public void setProjectNumber(String projectNumber) {
-        this.projectNumber = projectNumber;
-    }
-
-    /**
      * @return the Workload Identity Pool ID
      */
-    public String getPoolId() {
-        return poolId;
-    }
-
-    /**
-     * @param poolId the Workload Identity Pool ID
-     */
-    public void setPoolId(String poolId) {
-        this.poolId = poolId;
+    public String getWorkloadPool() {
+        return workloadPool;
     }
 
     /**
      * @return the Workload Identity Provider ID
      */
-    public String getProviderId() {
-        return providerId;
-    }
-
-    /**
-     * @param providerId the Workload Identity Provider ID
-     */
-    public void setProviderId(String providerId) {
-        this.providerId = providerId;
+    public String getWorkloadProvider() {
+        return workloadProvider;
     }
 
     /**
      * @return the GCP service account email to impersonate
      */
-    public String getServiceAccountEmail() {
-        return serviceAccountEmail;
-    }
-
-    /**
-     * @param serviceAccountEmail the GCP service account email to impersonate
-     */
-    public void setServiceAccountEmail(String serviceAccountEmail) {
-        this.serviceAccountEmail = serviceAccountEmail;
+    public String getServiceAccount() {
+        return serviceAccount;
     }
 
     /**
      * @return true if all required properties are configured
      */
     public boolean isFullyConfigured() {
-        return projectNumber != null && !projectNumber.isEmpty()
-                && poolId != null && !poolId.isEmpty()
-                && providerId != null && !providerId.isEmpty()
-                && serviceAccountEmail != null && !serviceAccountEmail.isEmpty();
+        return isNotEmpty(projectNumber)
+                && isNotEmpty(workloadPool)
+                && isNotEmpty(workloadProvider)
+                && isNotEmpty(serviceAccount);
+    }
+
+    private static boolean isNotEmpty(String value) {
+        return value != null && !value.isEmpty();
     }
 }

--- a/subprojects/micronaut-amazon-awssdk-gcp/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/gcp/AwsSecurityCredentialsSupplierBeanSpec.groovy
+++ b/subprojects/micronaut-amazon-awssdk-gcp/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/gcp/AwsSecurityCredentialsSupplierBeanSpec.groovy
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2018-2026 Agorapulse.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.agorapulse.micronaut.amazon.awssdk.gcp
+
+import com.google.auth.oauth2.AwsSecurityCredentialsSupplier
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import jakarta.inject.Inject
+import spock.lang.Specification
+
+@MicronautTest
+class AwsSecurityCredentialsSupplierBeanSpec extends Specification {
+
+    @Inject AwsSecurityCredentialsSupplier credentialsSupplier
+
+    void 'credentials supplier bean is available'() {
+        expect:
+            credentialsSupplier != null
+            credentialsSupplier instanceof AwsSecurityCredentialsSupplierBean
+    }
+
+    void 'credentials supplier returns region'() {
+        expect:
+            credentialsSupplier.getRegion(null) != null
+    }
+
+}

--- a/subprojects/micronaut-amazon-awssdk-gcp/src/test/resources/application-test.yml
+++ b/subprojects/micronaut-amazon-awssdk-gcp/src/test/resources/application-test.yml
@@ -1,0 +1,5 @@
+# Test configuration for AWS SDK GCP module
+aws:
+  region: us-east-1
+  accessKeyId: test-key
+  secretKey: test-secret


### PR DESCRIPTION
## Summary

Add new module `micronaut-amazon-awssdk-gcp` that enables GCP services (like Vertex AI) to authenticate using AWS credentials via Workload Identity Federation.

## New Module: micronaut-amazon-awssdk-gcp

### Components

- **AwsSecurityCredentialsSupplierBean**: Bridges AWS SDK credentials (`AwsCredentialsProvider`) to GCP's `AwsSecurityCredentialsSupplier` for WIF
- **GcpCredentialsFactory**: Creates `GoogleCredentials` bean using AWS WIF when configured
- **GcpWorkloadIdentityConfiguration**: Configuration properties for WIF parameters

### Configuration

```yaml
gcp:
  workload-identity:
    enabled: true
    project-number: "123456789012"
    pool-id: "aws-pool"
    provider-id: "aws-provider"
    service-account-email: "my-sa@project.iam.gserviceaccount.com"
```

### Use Cases

This module enables authentication with GCP services from AWS environments:
- **ECS**: Uses container credentials
- **Lambda**: Uses environment credentials  
- **EC2**: Uses instance metadata
- **Local development**: Uses profiles or environment variables

### Dependencies

- `micronaut-amazon-awssdk-core` (for AWS credential providers)
- `com.google.auth:google-auth-library-oauth2-http` (for GCP auth)

## Related

Extracted from platform PR #73678 to make this reusable across projects.