### PR TITLE
fix: prevent double-wrapping of results in createTableAndRetry

### DIFF
--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/main/java/com/agorapulse/micronaut/amazon/awssdk/dynamodb/AsyncDynamoDbServiceIntroduction.java
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/main/java/com/agorapulse/micronaut/amazon/awssdk/dynamodb/AsyncDynamoDbServiceIntroduction.java
@@ -100,12 +100,10 @@ public class AsyncDynamoDbServiceIntroduction implements DynamoDbServiceIntroduc
     }
 
     private <T> Object createTableAndRetry(MethodInvocationContext<Object, Object> context, AsyncDynamoDbService<T> service) {
-        return unwrapIfRequired(Flux.from(service.createTable()).handle((t, sink) -> {
-            Object result = doIntercept(context, service);
-            if (result != null) {
-                sink.next(result);
-            }
-        }), context);
+        // Wait for table creation to complete, then retry the operation
+        // doIntercept already handles unwrapping, so we must not wrap its result again
+        safeBlock(Mono.from(service.createTable()));
+        return doIntercept(context, service);
     }
 
     private static void logTypeConversionFailure(Class<?> type, Object result) {

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/java/com/agorapulse/micronaut/amazon/awssdk/dynamodb/DeleteFirstOperationTest.java
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/java/com/agorapulse/micronaut/amazon/awssdk/dynamodb/DeleteFirstOperationTest.java
@@ -55,6 +55,18 @@ public class DeleteFirstOperationTest {
     }
 
     @Test
+    public void findAllAsFirstOperationShouldReturnEmptyList() {
+        // findAll on a non-existent table should return empty list [], not [[]]
+        // This test verifies the fix for double-wrapping issue where createTableAndRetry
+        // was wrapping an already-unwrapped result
+        var result = service.findAllByOrganizationUid("nonexistent-org");
+        assertNotNull(result);
+        assertTrue(result.isEmpty(), "Result should be empty list");
+        // Verify it's not [[]] (list containing empty list) by checking it's actually empty
+        assertEquals(0, result.size(), "Result size should be 0, not 1 (which would indicate [[]])");
+    }
+
+    @Test
     public void deleteAfterFindAllShouldWork() {
         // reproduces the exact pattern from the failing spec setup method
         var items = service.findAllByOrganizationUid("org1");


### PR DESCRIPTION
## Problem

When the first operation on a DynamoDB service triggers table creation (because the table does not exist yet), the `createTableAndRetry` method was double-wrapping the result.

### Root Cause

`doIntercept()` already returns an **unwrapped** value (e.g., `List<T>`), but `createTableAndRetry` was:
1. Putting this unwrapped result into a Flux via `sink.next()`
2. Then calling `unwrapIfRequired` again on this Flux

This resulted in `[[]]` instead of `[]` for empty query results.

### Example

```java
// First call to findAllByEmail when table does not exist
List<User> result = service.findAllByEmail("test@example.com");
// Expected: []
// Actual before fix: [[]]
```

## Solution

Block on table creation first, then call `doIntercept` directly. Since `doIntercept` already handles unwrapping via `unwrapIfRequired`, we do not need to wrap again.

## Testing

Added test `findAllAsFirstOperationShouldReturnEmptyList()` that verifies the result is an empty list `[]`, not `[[]]`.