### PR TITLE
feat(kinesis): add ProcessRecordsEvent for custom metrics publishing

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -51,3 +51,6 @@ googleAuthVersion=1.23.0
 # project reactor version
 projectReactorVersion = 3.8.2
 
+# awaitility version
+awaitilityVersion = 4.2.0
+

--- a/subprojects/micronaut-amazon-awssdk-kinesis-worker/micronaut-amazon-awssdk-kinesis-worker.gradle
+++ b/subprojects/micronaut-amazon-awssdk-kinesis-worker/micronaut-amazon-awssdk-kinesis-worker.gradle
@@ -28,4 +28,5 @@ dependencies {
     testImplementation project(':micronaut-amazon-awssdk-integration-testing')
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "io.projectreactor:reactor-core:$projectReactorVersion"
+    testImplementation "org.awaitility:awaitility:4.2.0"
 }

--- a/subprojects/micronaut-amazon-awssdk-kinesis-worker/micronaut-amazon-awssdk-kinesis-worker.gradle
+++ b/subprojects/micronaut-amazon-awssdk-kinesis-worker/micronaut-amazon-awssdk-kinesis-worker.gradle
@@ -28,5 +28,5 @@ dependencies {
     testImplementation project(':micronaut-amazon-awssdk-integration-testing')
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "io.projectreactor:reactor-core:$projectReactorVersion"
-    testImplementation "org.awaitility:awaitility:4.2.0"
+    testImplementation "org.awaitility:awaitility:$awaitilityVersion"
 }

--- a/subprojects/micronaut-amazon-awssdk-kinesis-worker/src/main/groovy/com/agorapulse/micronaut/amazon/awssdk/kinesis/worker/DefaultKinesisWorker.java
+++ b/subprojects/micronaut-amazon-awssdk-kinesis-worker/src/main/groovy/com/agorapulse/micronaut/amazon/awssdk/kinesis/worker/DefaultKinesisWorker.java
@@ -42,7 +42,8 @@ class DefaultKinesisWorker implements KinesisWorker {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultKinesisWorker.class);
 
     private final KinesisClientConfiguration configuration;
-    private final ApplicationEventPublisher applicationEventPublisher;
+    private final ApplicationEventPublisher<WorkerStateEvent> workerStateEventPublisher;
+    private final ApplicationEventPublisher<ProcessRecordsEvent> processRecordsEventPublisher;
     private final Optional<DynamoDbAsyncClient> amazonDynamoDB;
     private final Optional<KinesisAsyncClient> amazonKinesis;
     private final Optional<CloudWatchAsyncClient> amazonCloudWatch;
@@ -53,13 +54,15 @@ class DefaultKinesisWorker implements KinesisWorker {
 
     DefaultKinesisWorker(
         KinesisClientConfiguration configuration,
-        ApplicationEventPublisher applicationEventPublisher,
+        ApplicationEventPublisher<WorkerStateEvent> workerStateEventPublisher,
+        ApplicationEventPublisher<ProcessRecordsEvent> processRecordsEventPublisher,
         Optional<DynamoDbAsyncClient> amazonDynamoDB,
         Optional<KinesisAsyncClient> amazonKinesis,
         Optional<CloudWatchAsyncClient> amazonCloudWatch
     ) {
         this.configuration = configuration;
-        this.applicationEventPublisher = applicationEventPublisher;
+        this.workerStateEventPublisher = workerStateEventPublisher;
+        this.processRecordsEventPublisher = processRecordsEventPublisher;
         this.amazonDynamoDB = amazonDynamoDB;
         this.amazonKinesis = amazonKinesis;
         this.amazonCloudWatch = amazonCloudWatch;
@@ -67,14 +70,16 @@ class DefaultKinesisWorker implements KinesisWorker {
 
     @Override
     public void start() {
-        ShardRecordProcessorFactory recordProcessorFactory = DefaultRecordProcessorFactory.create((string, record) ->
-            consumers.forEach(c -> {
+        ShardRecordProcessorFactory recordProcessorFactory = DefaultRecordProcessorFactory.create(
+            (string, record) -> consumers.forEach(c -> {
                 try {
                     c.accept(string, record);
                 } catch (Exception e) {
                     LOGGER.error("Exception processing Kinesis record " + record + " decoded as " + string, e);
                 }
-            })
+            }),
+            processRecordsEventPublisher,
+            configuration.getStream()
         );
 
         ConfigsBuilder configsBuilder = configuration.getConfigsBuilder(
@@ -84,7 +89,7 @@ class DefaultKinesisWorker implements KinesisWorker {
             recordProcessorFactory
         );
 
-        WorkerStateChangeListener workerStateChangeListener = s -> applicationEventPublisher.publishEvent(new WorkerStateEvent(s, configuration.getStream()));
+        WorkerStateChangeListener workerStateChangeListener = s -> workerStateEventPublisher.publishEvent(new WorkerStateEvent(s, configuration.getStream()));
 
         PollingConfig pollingConfig = new PollingConfig(configuration.getStream(), configsBuilder.kinesisClient());
 

--- a/subprojects/micronaut-amazon-awssdk-kinesis-worker/src/main/groovy/com/agorapulse/micronaut/amazon/awssdk/kinesis/worker/DefaultKinesisWorkerFactory.java
+++ b/subprojects/micronaut-amazon-awssdk-kinesis-worker/src/main/groovy/com/agorapulse/micronaut/amazon/awssdk/kinesis/worker/DefaultKinesisWorkerFactory.java
@@ -56,13 +56,21 @@ public class DefaultKinesisWorkerFactory implements KinesisWorkerFactory {
         }
     };
 
-    private final ApplicationEventPublisher applicationEventPublisher;
+    private final ApplicationEventPublisher<WorkerStateEvent> workerStateEventPublisher;
+    private final ApplicationEventPublisher<ProcessRecordsEvent> processRecordsEventPublisher;
     private final Optional<DynamoDbAsyncClient> amazonDynamoDB;
     private final Optional<KinesisAsyncClient> kinesis;
     private final Optional<CloudWatchAsyncClient> cloudWatch;
 
-    public DefaultKinesisWorkerFactory(ApplicationEventPublisher applicationEventPublisher, Optional<DynamoDbAsyncClient> amazonDynamoDB, Optional<KinesisAsyncClient> kinesis, Optional<CloudWatchAsyncClient> cloudWatch) {
-        this.applicationEventPublisher = applicationEventPublisher;
+    public DefaultKinesisWorkerFactory(
+        ApplicationEventPublisher<WorkerStateEvent> workerStateEventPublisher,
+        ApplicationEventPublisher<ProcessRecordsEvent> processRecordsEventPublisher,
+        Optional<DynamoDbAsyncClient> amazonDynamoDB,
+        Optional<KinesisAsyncClient> kinesis,
+        Optional<CloudWatchAsyncClient> cloudWatch
+    ) {
+        this.workerStateEventPublisher = workerStateEventPublisher;
+        this.processRecordsEventPublisher = processRecordsEventPublisher;
         this.amazonDynamoDB = amazonDynamoDB;
         this.kinesis = kinesis;
         this.cloudWatch = cloudWatch;
@@ -79,7 +87,14 @@ public class DefaultKinesisWorkerFactory implements KinesisWorkerFactory {
             return NOOP;
         }
 
-        return new DefaultKinesisWorker(kinesisConfiguration, applicationEventPublisher, amazonDynamoDB, kinesis, cloudWatch);
+        return new DefaultKinesisWorker(
+            kinesisConfiguration,
+            workerStateEventPublisher,
+            processRecordsEventPublisher,
+            amazonDynamoDB,
+            kinesis,
+            cloudWatch
+        );
     }
 
 }

--- a/subprojects/micronaut-amazon-awssdk-kinesis-worker/src/main/groovy/com/agorapulse/micronaut/amazon/awssdk/kinesis/worker/DefaultRecordProcessor.java
+++ b/subprojects/micronaut-amazon-awssdk-kinesis-worker/src/main/groovy/com/agorapulse/micronaut/amazon/awssdk/kinesis/worker/DefaultRecordProcessor.java
@@ -119,17 +119,18 @@ class DefaultRecordProcessor implements ShardRecordProcessor {
     }
 
     private void publishProcessRecordsEvent(ProcessRecordsInput input) {
-        try {
-            ProcessRecordsEvent event = new ProcessRecordsEvent(
-                stream,
-                shardId,
-                input.millisBehindLatest(),
-                input.records().size()
-            );
-            eventPublisher.publishEvent(event);
-        } catch (Exception e) {
-            LOGGER.warn("[{}] Failed to publish ProcessRecordsEvent", shardId, e);
-        }
+        // Publish asynchronously to avoid blocking record processing or breaking the flow
+        ProcessRecordsEvent event = new ProcessRecordsEvent(
+            stream,
+            shardId,
+            input.millisBehindLatest(),
+            input.records().size()
+        );
+        eventPublisher.publishEventAsync(event).whenComplete((result, error) -> {
+            if (error != null) {
+                LOGGER.warn("[{}] Failed to publish ProcessRecordsEvent", shardId, error);
+            }
+        });
     }
 
     private DefaultRecordProcessor(

--- a/subprojects/micronaut-amazon-awssdk-kinesis-worker/src/main/groovy/com/agorapulse/micronaut/amazon/awssdk/kinesis/worker/DefaultRecordProcessor.java
+++ b/subprojects/micronaut-amazon-awssdk-kinesis-worker/src/main/groovy/com/agorapulse/micronaut/amazon/awssdk/kinesis/worker/DefaultRecordProcessor.java
@@ -126,9 +126,11 @@ class DefaultRecordProcessor implements ShardRecordProcessor {
             input.millisBehindLatest(),
             input.records().size()
         );
-        eventPublisher.publishEventAsync(event).whenComplete((result, error) -> {
-            if (error != null) {
-                LOGGER.warn("[{}] Failed to publish ProcessRecordsEvent", shardId, error);
+        java.util.concurrent.CompletableFuture.runAsync(() -> {
+            try {
+                eventPublisher.publishEvent(event);
+            } catch (Exception e) {
+                LOGGER.warn("[{}] Failed to publish ProcessRecordsEvent", shardId, e);
             }
         });
     }

--- a/subprojects/micronaut-amazon-awssdk-kinesis-worker/src/main/groovy/com/agorapulse/micronaut/amazon/awssdk/kinesis/worker/DefaultRecordProcessor.java
+++ b/subprojects/micronaut-amazon-awssdk-kinesis-worker/src/main/groovy/com/agorapulse/micronaut/amazon/awssdk/kinesis/worker/DefaultRecordProcessor.java
@@ -17,6 +17,7 @@
  */
 package com.agorapulse.micronaut.amazon.awssdk.kinesis.worker;
 
+import io.micronaut.context.event.ApplicationEventPublisher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,13 +53,19 @@ class DefaultRecordProcessor implements ShardRecordProcessor {
     // Checkpoint about once a minute
     private static final long CHECKPOINT_INTERVAL_MILLIS = 60000L;
 
-    static ShardRecordProcessor create(BiConsumer<String, KinesisClientRecord> consumer) {
-        return new DefaultRecordProcessor(consumer);
+    static ShardRecordProcessor create(
+        BiConsumer<String, KinesisClientRecord> consumer,
+        ApplicationEventPublisher<ProcessRecordsEvent> eventPublisher,
+        String stream
+    ) {
+        return new DefaultRecordProcessor(consumer, eventPublisher, stream);
     }
 
     private long nextCheckpointTimeInMillis;
     private final CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder();
     private final BiConsumer<String, KinesisClientRecord> processor;
+    private final ApplicationEventPublisher<ProcessRecordsEvent> eventPublisher;
+    private final String stream;
 
     private String shardId = "";
 
@@ -101,6 +108,9 @@ class DefaultRecordProcessor implements ShardRecordProcessor {
         // Process records and perform all exception handling.
         processRecordsWithRetries(input.records());
 
+        // Publish event for metrics/monitoring
+        publishProcessRecordsEvent(input);
+
         // Checkpoint once every checkpoint interval.
         if (System.currentTimeMillis() > nextCheckpointTimeInMillis) {
             checkpoint(input.checkpointer());
@@ -108,8 +118,28 @@ class DefaultRecordProcessor implements ShardRecordProcessor {
         }
     }
 
-    private DefaultRecordProcessor(BiConsumer<String, KinesisClientRecord> processor) {
+    private void publishProcessRecordsEvent(ProcessRecordsInput input) {
+        try {
+            ProcessRecordsEvent event = new ProcessRecordsEvent(
+                stream,
+                shardId,
+                input.millisBehindLatest(),
+                input.records().size()
+            );
+            eventPublisher.publishEvent(event);
+        } catch (Exception e) {
+            LOGGER.warn("[{}] Failed to publish ProcessRecordsEvent", shardId, e);
+        }
+    }
+
+    private DefaultRecordProcessor(
+        BiConsumer<String, KinesisClientRecord> processor,
+        ApplicationEventPublisher<ProcessRecordsEvent> eventPublisher,
+        String stream
+    ) {
         this.processor = processor;
+        this.eventPublisher = eventPublisher;
+        this.stream = stream;
     }
 
     /**

--- a/subprojects/micronaut-amazon-awssdk-kinesis-worker/src/main/groovy/com/agorapulse/micronaut/amazon/awssdk/kinesis/worker/DefaultRecordProcessorFactory.java
+++ b/subprojects/micronaut-amazon-awssdk-kinesis-worker/src/main/groovy/com/agorapulse/micronaut/amazon/awssdk/kinesis/worker/DefaultRecordProcessorFactory.java
@@ -17,6 +17,7 @@
  */
 package com.agorapulse.micronaut.amazon.awssdk.kinesis.worker;
 
+import io.micronaut.context.event.ApplicationEventPublisher;
 import software.amazon.kinesis.processor.ShardRecordProcessor;
 import software.amazon.kinesis.processor.ShardRecordProcessorFactory;
 import software.amazon.kinesis.retrieval.KinesisClientRecord;
@@ -26,18 +27,30 @@ import java.util.function.BiConsumer;
 class DefaultRecordProcessorFactory implements ShardRecordProcessorFactory {
 
     private final BiConsumer<String, KinesisClientRecord> consumer;
+    private final ApplicationEventPublisher<ProcessRecordsEvent> eventPublisher;
+    private final String stream;
 
-    static ShardRecordProcessorFactory create(BiConsumer<String, KinesisClientRecord> consumer) {
-        return new DefaultRecordProcessorFactory(consumer);
+    static ShardRecordProcessorFactory create(
+        BiConsumer<String, KinesisClientRecord> consumer,
+        ApplicationEventPublisher<ProcessRecordsEvent> eventPublisher,
+        String stream
+    ) {
+        return new DefaultRecordProcessorFactory(consumer, eventPublisher, stream);
     }
 
-    private DefaultRecordProcessorFactory(BiConsumer<String, KinesisClientRecord> consumer) {
+    private DefaultRecordProcessorFactory(
+        BiConsumer<String, KinesisClientRecord> consumer,
+        ApplicationEventPublisher<ProcessRecordsEvent> eventPublisher,
+        String stream
+    ) {
         this.consumer = consumer;
+        this.eventPublisher = eventPublisher;
+        this.stream = stream;
     }
 
     @Override
     public ShardRecordProcessor shardRecordProcessor() {
-        return DefaultRecordProcessor.create(consumer);
+        return DefaultRecordProcessor.create(consumer, eventPublisher, stream);
     }
 
 

--- a/subprojects/micronaut-amazon-awssdk-kinesis-worker/src/main/groovy/com/agorapulse/micronaut/amazon/awssdk/kinesis/worker/ProcessRecordsEvent.java
+++ b/subprojects/micronaut-amazon-awssdk-kinesis-worker/src/main/groovy/com/agorapulse/micronaut/amazon/awssdk/kinesis/worker/ProcessRecordsEvent.java
@@ -1,0 +1,119 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2018-2026 Agorapulse.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.agorapulse.micronaut.amazon.awssdk.kinesis.worker;
+
+import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
+
+/**
+ * Event published after processing a batch of Kinesis records.
+ * <p>
+ * This event can be used to publish custom metrics (e.g., to Datadog) based on
+ * the Kinesis consumer state, particularly the {@link #getMillisBehindLatest()} value
+ * which indicates how far behind the consumer is from the stream tip.
+ * <p>
+ * Example usage:
+ * <pre>{@code
+ * @Singleton
+ * public class KinesisMetricsPublisher {
+ *     
+ *     private final MeterRegistry meterRegistry;
+ *     
+ *     public KinesisMetricsPublisher(MeterRegistry meterRegistry) {
+ *         this.meterRegistry = meterRegistry;
+ *     }
+ *     
+ *     @EventListener
+ *     void onProcessRecords(ProcessRecordsEvent event) {
+ *         if (event.getMillisBehindLatest() != null) {
+ *             meterRegistry.gauge("kinesis.consumer.millisBehindLatest",
+ *                 Tags.of("stream", event.getStream(), "shard", event.getShardId()),
+ *                 event.getMillisBehindLatest());
+ *         }
+ *     }
+ * }
+ * }</pre>
+ */
+public class ProcessRecordsEvent {
+
+    private final String stream;
+    private final String shardId;
+    private final Long millisBehindLatest;
+    private final int recordCount;
+
+    public ProcessRecordsEvent(
+        @NonNull String stream,
+        @NonNull String shardId,
+        @Nullable Long millisBehindLatest,
+        int recordCount
+    ) {
+        this.stream = stream;
+        this.shardId = shardId;
+        this.millisBehindLatest = millisBehindLatest;
+        this.recordCount = recordCount;
+    }
+
+    /**
+     * @return the name of the Kinesis stream
+     */
+    @NonNull
+    public String getStream() {
+        return stream;
+    }
+
+    /**
+     * @return the shard ID being processed
+     */
+    @NonNull
+    public String getShardId() {
+        return shardId;
+    }
+
+    /**
+     * Returns the number of milliseconds the consumer is behind the tip of the stream.
+     * <p>
+     * This value is useful for monitoring consumer lag. A high value indicates the consumer
+     * is falling behind and may need scaling or optimization.
+     * <p>
+     * Note: This value may be null if not provided by the Kinesis Client Library.
+     *
+     * @return milliseconds behind the latest record in the stream, or null if not available
+     */
+    @Nullable
+    public Long getMillisBehindLatest() {
+        return millisBehindLatest;
+    }
+
+    /**
+     * @return the number of records in this batch
+     */
+    public int getRecordCount() {
+        return recordCount;
+    }
+
+    @Override
+    public String toString() {
+        return "ProcessRecordsEvent{" +
+            "stream='" + stream + '\'' +
+            ", shardId='" + shardId + '\'' +
+            ", millisBehindLatest=" + millisBehindLatest +
+            ", recordCount=" + recordCount +
+            '}';
+    }
+
+}

--- a/subprojects/micronaut-amazon-awssdk-kinesis-worker/src/main/groovy/com/agorapulse/micronaut/amazon/awssdk/kinesis/worker/ProcessRecordsEvent.java
+++ b/subprojects/micronaut-amazon-awssdk-kinesis-worker/src/main/groovy/com/agorapulse/micronaut/amazon/awssdk/kinesis/worker/ProcessRecordsEvent.java
@@ -108,12 +108,12 @@ public class ProcessRecordsEvent {
 
     @Override
     public String toString() {
-        return "ProcessRecordsEvent{" +
-            "stream='" + stream + '\'' +
-            ", shardId='" + shardId + '\'' +
-            ", millisBehindLatest=" + millisBehindLatest +
-            ", recordCount=" + recordCount +
-            '}';
+        return "ProcessRecordsEvent{"
+            + "stream='" + stream + '\''
+            + ", shardId='" + shardId + '\''
+            + ", millisBehindLatest=" + millisBehindLatest
+            + ", recordCount=" + recordCount
+            + '}';
     }
 
 }

--- a/subprojects/micronaut-amazon-awssdk-kinesis-worker/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/kinesis/worker/KinesisTest.java
+++ b/subprojects/micronaut-amazon-awssdk-kinesis-worker/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/kinesis/worker/KinesisTest.java
@@ -52,6 +52,7 @@ public class KinesisTest {
     @Inject KinesisListenerTester tester;
     @Inject DefaultClient client;
     @Inject WorkerStateListener listener;
+    @Inject ProcessRecordsEventCollector processRecordsEventCollector;
 
     // tag::testcontainers-test[]
     @Test
@@ -66,6 +67,18 @@ public class KinesisTest {
         subscription.dispose();
 
         Assertions.assertTrue(allTestEventsReceived(tester));
+        
+        // Verify ProcessRecordsEvent was published (async events need a small delay)
+        Thread.sleep(100);
+        Assertions.assertTrue(processRecordsEventCollector.hasReceivedEvents(), 
+            "ProcessRecordsEvent should have been published");
+        
+        // Verify event properties
+        ProcessRecordsEvent firstEvent = processRecordsEventCollector.getEvents().get(0);
+        Assertions.assertEquals(TEST_STREAM, firstEvent.getStream());
+        Assertions.assertNotNull(firstEvent.getShardId());
+        // millisBehindLatest may be null in test environment, so we just check it doesn't throw
+        firstEvent.getMillisBehindLatest();
     }
     // end::testcontainers-test[]
 

--- a/subprojects/micronaut-amazon-awssdk-kinesis-worker/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/kinesis/worker/KinesisTest.java
+++ b/subprojects/micronaut-amazon-awssdk-kinesis-worker/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/kinesis/worker/KinesisTest.java
@@ -20,6 +20,7 @@ package com.agorapulse.micronaut.amazon.awssdk.kinesis.worker;
 import com.agorapulse.micronaut.amazon.awssdk.kinesis.KinesisService;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import reactor.core.Disposable;
@@ -68,17 +69,18 @@ public class KinesisTest {
 
         Assertions.assertTrue(allTestEventsReceived(tester));
         
-        // Verify ProcessRecordsEvent was published (async events need a small delay)
-        Thread.sleep(100);
-        Assertions.assertTrue(processRecordsEventCollector.hasReceivedEvents(), 
-            "ProcessRecordsEvent should have been published");
-        
-        // Verify event properties
-        ProcessRecordsEvent firstEvent = processRecordsEventCollector.getEvents().get(0);
-        Assertions.assertEquals(TEST_STREAM, firstEvent.getStream());
-        Assertions.assertNotNull(firstEvent.getShardId());
-        // millisBehindLatest may be null in test environment, so we just check it doesn't throw
-        firstEvent.getMillisBehindLatest();
+        // Verify ProcessRecordsEvent was published (async events)
+        Awaitility.await()
+            .atMost(Duration.ofSeconds(5))
+            .untilAsserted(() -> {
+                Assertions.assertTrue(processRecordsEventCollector.hasReceivedEvents(), 
+                    "ProcessRecordsEvent should have been published");
+                
+                // Verify event properties
+                ProcessRecordsEvent firstEvent = processRecordsEventCollector.getEvents().get(0);
+                Assertions.assertEquals(TEST_STREAM, firstEvent.getStream());
+                Assertions.assertNotNull(firstEvent.getShardId());
+            });
     }
     // end::testcontainers-test[]
 

--- a/subprojects/micronaut-amazon-awssdk-kinesis-worker/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/kinesis/worker/KinesisTest.java
+++ b/subprojects/micronaut-amazon-awssdk-kinesis-worker/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/kinesis/worker/KinesisTest.java
@@ -20,7 +20,6 @@ package com.agorapulse.micronaut.amazon.awssdk.kinesis.worker;
 import com.agorapulse.micronaut.amazon.awssdk.kinesis.KinesisService;
 import io.micronaut.context.annotation.Property;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import reactor.core.Disposable;
@@ -70,7 +69,7 @@ public class KinesisTest {
         Assertions.assertTrue(allTestEventsReceived(tester));
         
         // Verify ProcessRecordsEvent was published (async events)
-        Awaitility.await()
+        org.awaitility.Awaitility.await()
             .atMost(Duration.ofSeconds(5))
             .untilAsserted(() -> {
                 Assertions.assertTrue(processRecordsEventCollector.hasReceivedEvents(), 

--- a/subprojects/micronaut-amazon-awssdk-kinesis-worker/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/kinesis/worker/ProcessRecordsEventCollector.java
+++ b/subprojects/micronaut-amazon-awssdk-kinesis-worker/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/kinesis/worker/ProcessRecordsEventCollector.java
@@ -1,0 +1,56 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2018-2026 Agorapulse.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.agorapulse.micronaut.amazon.awssdk.kinesis.worker;
+
+import io.micronaut.runtime.event.annotation.EventListener;
+import jakarta.inject.Singleton;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+/**
+ * Test collector for ProcessRecordsEvent.
+ * Demonstrates how users can subscribe to the event for custom metrics publishing.
+ */
+@Singleton
+public class ProcessRecordsEventCollector {
+
+    private final List<ProcessRecordsEvent> events = new CopyOnWriteArrayList<>();
+
+    @EventListener
+    void onProcessRecords(ProcessRecordsEvent event) {
+        events.add(event);
+        System.err.println("Received ProcessRecordsEvent: stream=" + event.getStream() 
+            + ", shard=" + event.getShardId() 
+            + ", millisBehindLatest=" + event.getMillisBehindLatest()
+            + ", recordCount=" + event.getRecordCount());
+    }
+
+    public List<ProcessRecordsEvent> getEvents() {
+        return events;
+    }
+
+    public boolean hasReceivedEvents() {
+        return !events.isEmpty();
+    }
+
+    public void clear() {
+        events.clear();
+    }
+
+}

--- a/subprojects/micronaut-amazon-awssdk-kinesis-worker/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/kinesis/worker/ProcessRecordsEventTest.java
+++ b/subprojects/micronaut-amazon-awssdk-kinesis-worker/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/kinesis/worker/ProcessRecordsEventTest.java
@@ -1,0 +1,68 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2018-2026 Agorapulse.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.agorapulse.micronaut.amazon.awssdk.kinesis.worker;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ProcessRecordsEventTest {
+
+    @Test
+    void eventShouldContainAllProperties() {
+        // given
+        String stream = "test-stream";
+        String shardId = "shard-001";
+        Long millisBehindLatest = 5000L;
+        int recordCount = 10;
+
+        // when
+        ProcessRecordsEvent event = new ProcessRecordsEvent(stream, shardId, millisBehindLatest, recordCount);
+
+        // then
+        assertEquals(stream, event.getStream());
+        assertEquals(shardId, event.getShardId());
+        assertEquals(millisBehindLatest, event.getMillisBehindLatest());
+        assertEquals(recordCount, event.getRecordCount());
+    }
+
+    @Test
+    void eventShouldAllowNullMillisBehindLatest() {
+        // given
+        ProcessRecordsEvent event = new ProcessRecordsEvent("stream", "shard", null, 5);
+
+        // then
+        assertNull(event.getMillisBehindLatest());
+    }
+
+    @Test
+    void toStringShouldContainAllProperties() {
+        // given
+        ProcessRecordsEvent event = new ProcessRecordsEvent("my-stream", "shard-123", 1000L, 50);
+
+        // when
+        String str = event.toString();
+
+        // then
+        assertTrue(str.contains("my-stream"));
+        assertTrue(str.contains("shard-123"));
+        assertTrue(str.contains("1000"));
+        assertTrue(str.contains("50"));
+    }
+
+}


### PR DESCRIPTION
## Summary

Add `ProcessRecordsEvent` that is published after each batch of Kinesis records is processed. This allows users to publish custom metrics (e.g., to Datadog) based on the Kinesis consumer state.

## Motivation

The `millisBehindLatest` value from KCL is only sent to CloudWatch by default. Users who use Datadog or other monitoring systems need a way to access this metric.

## Changes

- Add `ProcessRecordsEvent` class with:
  - `stream` - the Kinesis stream name
  - `shardId` - the shard being processed
  - `millisBehindLatest` - how far behind the consumer is (the key metric for monitoring lag)
  - `recordCount` - number of records in the batch
- Publish the event from `DefaultRecordProcessor.processRecords()`
- Update factories to pass the event publisher through the chain

## Usage Example

```java
@Singleton
public class KinesisMetricsPublisher {
    
    private final MeterRegistry meterRegistry;
    
    public KinesisMetricsPublisher(MeterRegistry meterRegistry) {
        this.meterRegistry = meterRegistry;
    }
    
    @EventListener
    void onProcessRecords(ProcessRecordsEvent event) {
        if (event.getMillisBehindLatest() != null) {
            meterRegistry.gauge("kinesis.consumer.millisBehindLatest",
                Tags.of("stream", event.getStream(), "shard", event.getShardId()),
                event.getMillisBehindLatest());
        }
    }
}
```

## Testing

- [ ] Add unit test for event publishing
- [ ] Verify existing tests still pass

## Related

Addresses the need to monitor Kinesis consumer lag in Datadog without modifying library internals.