### PR TITLE
chore: upgrade Kinesis Client Library to 2.7.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -43,7 +43,7 @@ groovyVersion = 4.0.16
 jackson.datatype.version=2.9.7
 
 # kinesis client version
-kinesisClientV2Version=2.7.0
+kinesisClientV2Version=2.7.2
 
 # google auth library version
 googleAuthVersion=1.23.0


### PR DESCRIPTION
## Summary

Upgrade Kinesis Client Library from 2.7.0 to 2.7.2.

## Changes in 2.7.1
- Upgrade schema-registry-common and schema-registry-serde from 1.1.19 to 1.1.24

## Changes in 2.7.2
- Upgrade awssdk from 2.25.64 to 2.33.0
- Upgrade apache.commons from 3.14.0 to 3.18.0
- Bump protobuf-java from 4.27.5 to 4.31.1

## Why not KCL 3.x?

KCL 3.x is available (latest: 3.4.1) but requires significant migration effort:
- New lease assignment algorithm based on worker utilization metrics
- **Two new DynamoDB tables** required (worker metrics table, coordinator state table)
- IAM permission changes required
- Configuration property changes

Upgrading to 3.x should be a separate, planned effort with proper testing.

## References
- [KCL 2.7.1 Release](https://github.com/awslabs/amazon-kinesis-client/releases/tag/v2.7.1)
- [KCL 2.7.2 Release](https://github.com/awslabs/amazon-kinesis-client/releases/tag/v2.7.2)
- [KCL 3.x Migration Guide](https://docs.aws.amazon.com/streams/latest/dev/kcl-migration-from-2-3.html)