### PR TITLE
chore: pin LocalStack to 3.8.1 to avoid auth requirement

### DIFF
--- a/subprojects/micronaut-amazon-awssdk-integration-testing/src/main/java/com/agorapulse/micronaut/amazon/awssdk/itest/localstack/LocalstackContainerConfiguration.java
+++ b/subprojects/micronaut-amazon-awssdk-integration-testing/src/main/java/com/agorapulse/micronaut/amazon/awssdk/itest/localstack/LocalstackContainerConfiguration.java
@@ -32,7 +32,7 @@ public class LocalstackContainerConfiguration extends AbstractContainerConfigura
     );
 
     public static final String DEFAULT_IMAGE = "localstack/localstack";
-    public static final String DEFAULT_TAG = "3.2.0";
+    public static final String DEFAULT_TAG = "3.8.1";
 
     public LocalstackContainerConfiguration() {
         setImage(DEFAULT_IMAGE);


### PR DESCRIPTION
## Summary

Pin LocalStack default version to 3.8.1 to avoid the new authentication requirement.

## Problem

LocalStack v4+ now requires authentication for all usage:
- **Hobby tier**: Free but **prohibits commercial use**
- **Base tier**: $35/user/month
- **Ultimate tier**: $99/user/month

The latest LocalStack image fails with:
```
LocalStack requires an account to run.
No credentials were found in the environment.
```

## Solution

Pin to `localstack/localstack:3.8.1` which is the last version before auth was enforced.

Changed `DEFAULT_TAG` from `3.2.0` to `3.8.1` in `LocalstackContainerConfiguration.java`.

## Future Alternatives

For long-term, we should evaluate:
- **DynamoDB Local** (AWS official, free)
- **ElasticMQ** (SQS mock, Apache 2.0)
- **Adobe S3Mock** (S3 mock, Apache 2.0)
- Individual service mocks vs. LocalStack

## References

- [LocalStack Pricing](https://www.localstack.cloud/pricing)
- [LocalStack v4 Release Notes](https://github.com/localstack/localstack/issues/11803)