### PR TITLE
Replace RxJava2 Flowable with Project Reactor Flux

### DIFF
--- a/kotlin-libs/micronaut-amazon-awssdk-dynamodb-kotlin/src/main/kotlin/com/agorapulse/micronaut/amazon/awssdk/dynamodb/kotlin/ScanBuilder.kt
+++ b/kotlin-libs/micronaut-amazon-awssdk-dynamodb-kotlin/src/main/kotlin/com/agorapulse/micronaut/amazon/awssdk/dynamodb/kotlin/ScanBuilder.kt
@@ -72,7 +72,7 @@ class ScanBuilder<T>(private val delegate: com.agorapulse.micronaut.amazon.awssd
      *
      * This only sets the optimal pagination of the scans and does not limit the number of items returned.
      *
-     * Use `[io.reactivex.Flowable.take]` to limit the number results returned from the scan.
+     * Use `[reactor.core.publisher.Flux.take]` to limit the number results returned from the scan.
      *
      * @param page number of entities loaded by one scan request (not a number of total entities returned)
      * @return self
@@ -85,7 +85,7 @@ class ScanBuilder<T>(private val delegate: com.agorapulse.micronaut.amazon.awssd
     /**
      * Sets the maximum number of items to be returned from the queries.
      *
-     * This is a shortcut for calling `[io.reactivex.Flowable.take]` on the result Flowable.
+     * This is a shortcut for calling `[reactor.core.publisher.Flux.take]` on the result Flux.
      *
      * @param max the maximum number of items returned
      * @return self

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/micronaut-amazon-awssdk-dynamodb.gradle
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/micronaut-amazon-awssdk-dynamodb.gradle
@@ -30,7 +30,6 @@ dependencies {
     testAnnotationProcessor project(':micronaut-amazon-awssdk-dynamodb-annotation-processor')
     testImplementation project(':micronaut-amazon-awssdk-dynamodb-annotation-processor')
     testImplementation project(':micronaut-amazon-awssdk-integration-testing')
-    testImplementation 'io.micronaut.rxjava2:micronaut-rxjava2'
     testImplementation 'io.micronaut:micronaut-jackson-databind'
 
     testImplementation "software.amazon.awssdk:aws-crt-client:$project.awsSdk2Version"

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/main/java/com/agorapulse/micronaut/amazon/awssdk/dynamodb/builder/QueryBuilder.java
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/main/java/com/agorapulse/micronaut/amazon/awssdk/dynamodb/builder/QueryBuilder.java
@@ -126,7 +126,7 @@ public interface QueryBuilder<T> extends DetachedQuery<T> {
      *
      * This only sets the optimal pagination of the queries and does not limit the number of items returned.
      *
-     * Use <code>{@link io.reactivex.Flowable#take(long)}</code> to limit the number results returned from the query.
+     * Use <code>{@link reactor.core.publisher.Flux#take(long)}</code> to limit the number results returned from the query.
      *
      * @param page number of entities loaded by one query request (not a number of total entities returned)
      * @return self
@@ -136,7 +136,7 @@ public interface QueryBuilder<T> extends DetachedQuery<T> {
     /**
      * Sets the maximum number of items to be returned from the queries.
      *
-     * This is a shortcut for calling <code>{@link io.reactivex.Flowable#take(long)}</code> on the result Flowable.
+     * This is a shortcut for calling <code>{@link reactor.core.publisher.Flux#take(long)}</code> on the result Flux.
      *
      * @param max the maximum number of items returned
      * @return self

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/main/java/com/agorapulse/micronaut/amazon/awssdk/dynamodb/builder/ScanBuilder.java
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/main/java/com/agorapulse/micronaut/amazon/awssdk/dynamodb/builder/ScanBuilder.java
@@ -62,7 +62,7 @@ public interface ScanBuilder<T> extends DetachedScan<T> {
      *
      * This only sets the optimal pagination of the scans and does not limit the number of items returned.
      *
-     * Use <code>{@link io.reactivex.Flowable#take(long)}</code> to limit the number results returned from the scan.
+     * Use <code>{@link reactor.core.publisher.Flux#take(long)}</code> to limit the number results returned from the scan.
      *
      * @param page number of entities loaded by one scan request (not a number of total entities returned)
      * @return self
@@ -72,7 +72,7 @@ public interface ScanBuilder<T> extends DetachedScan<T> {
     /**
      * Sets the maximum number of items to be returned from the queries.
      *
-     * This is a shortcut for calling <code>{@link io.reactivex.Flowable#take(long)}</code> on the result Flowable.
+     * This is a shortcut for calling <code>{@link reactor.core.publisher.Flux#take(long)}</code> on the result Flux.
      *
      * @param max the maximum number of items returned
      * @return self

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/DefaultDynamoDBServiceNoRangeSpec.groovy
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/DefaultDynamoDBServiceNoRangeSpec.groovy
@@ -20,7 +20,7 @@ package com.agorapulse.micronaut.amazon.awssdk.dynamodb
 import com.agorapulse.micronaut.amazon.awssdk.core.client.ClientBuilderProvider
 import io.micronaut.context.annotation.Property
 import io.micronaut.test.extensions.spock.annotation.MicronautTest
-import io.reactivex.Flowable
+import reactor.core.publisher.Flux
 import spock.lang.Specification
 
 import jakarta.inject.Inject
@@ -43,10 +43,10 @@ class DefaultDynamoDBServiceNoRangeSpec extends Specification {
                 new DynamoDBEntityNoRange(parentId: '3'),
                 new DynamoDBEntityNoRange(parentId: '4')]
             ).collectList().block()
-            service.saveAll(Flowable.just(
+            service.saveAll(Flux.just(
                 new DynamoDBEntityNoRange(parentId: '5'),
                 new DynamoDBEntityNoRange(parentId: '6')
-            )).toList().blockingGet()
+            )).collectList().block()
 
         then:
             noExceptionThrown()

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/DynamoDBEntityNoRangeService.java
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/DynamoDBEntityNoRangeService.java
@@ -24,7 +24,6 @@ import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.Update;
 import com.agorapulse.micronaut.amazon.awssdk.dynamodb.builder.Builders;
 import com.agorapulse.micronaut.amazon.awssdk.dynamodb.builder.DetachedQuery;
 import com.agorapulse.micronaut.amazon.awssdk.dynamodb.builder.DetachedUpdate;
-import io.reactivex.Flowable;
 import reactor.core.publisher.Flux;
 
 import java.util.List;
@@ -37,9 +36,9 @@ public interface DynamoDBEntityNoRangeService {
     DynamoDBEntityNoRange get(@PartitionKey String parentId);
     List<DynamoDBEntityNoRange> getAll(@PartitionKey List<String> parentIds);
     DynamoDBEntityNoRange save(DynamoDBEntityNoRange entity);
-    Flowable<DynamoDBEntityNoRange> saveAll(DynamoDBEntityNoRange... entities);
+    Flux<DynamoDBEntityNoRange> saveAll(DynamoDBEntityNoRange... entities);
 
-    Flowable<DynamoDBEntityNoRange> saveAll(Flowable<DynamoDBEntityNoRange> entities);
+    Flux<DynamoDBEntityNoRange> saveAll(Flux<DynamoDBEntityNoRange> entities);
 
     Flux<DynamoDBEntityNoRange> saveAll(Iterable<DynamoDBEntityNoRange> entities);
 


### PR DESCRIPTION
## Summary
This PR migrates the DynamoDB service from RxJava2's `Flowable` to Project Reactor's `Flux` for reactive stream handling. This aligns with Micronaut's shift towards Project Reactor as the primary reactive library.

## Key Changes
- **Import updates**: Replaced `io.reactivex.Flowable` imports with `reactor.core.publisher.Flux`
- **API signature changes**: Updated `DynamoDBEntityNoRangeService` interface methods to return `Flux<DynamoDBEntityNoRange>` instead of `Flowable<DynamoDBEntityNoRange>`
- **Test updates**: 
  - Changed test code to use `Flux.just()` instead of `Flowable.just()`
  - Updated reactive chain calls from `.toList().blockingGet()` to `.collectList().block()` for Reactor API compatibility
- **Documentation updates**: Updated JavaDoc and KDoc comments to reference `Flux` and `reactor.core.publisher` instead of `Flowable` and `io.reactivex`
- **Dependency cleanup**: Removed `io.micronaut.rxjava2:micronaut-rxjava2` test dependency

## Implementation Details
The migration maintains functional equivalence while adopting Reactor's API patterns:
- `Flowable.just()` → `Flux.just()`
- `.toList().blockingGet()` → `.collectList().block()`
- All documentation references updated to point to Reactor's `Flux` class and methods

https://claude.ai/code/session_018txiCmGwYZugNNQm8wiurw