### PR TITLE
Add MiniStack integration testing support as LocalStack alternative

### DIFF
--- a/docs/guide/src/docs/asciidoc/dynamodb.adoc
+++ b/docs/guide/src/docs/asciidoc/dynamodb.adoc
@@ -960,6 +960,18 @@ aws:
     create-tables: true
 ----
 
+You can also use https://ministack.org/[MiniStack] as a drop-in alternative to LocalStack by enabling the `ministack` configuration. When `ministack.enabled` is `true`, the LocalStack container is not started.
+
+[source,yaml]
+.application-test.yml
+----
+ministack:
+  enabled: true
+  shared: true
+----
+
+The same per-service container override mechanism is available via `ministack.containers.<service>` (for example to substitute a real `amazon/dynamodb-local` container).
+
 ====
 
 ==== Data Loader

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,6 +25,7 @@ awsSdk2Version = 2.41.16
 awsLambdaRuntimeVersion=2.5.0
 awsLambdaEventsVersion=3.16.1
 testcontainersVersion = 1.17.3
+ministackVersion = 0.1.5
 kordampVersion=0.53.0
 gitPublishPluginVersion=2.1.3
 mavenCentralPublishPluginVersion=0.34.0

--- a/subprojects/micronaut-amazon-awssdk-integration-testing/micronaut-amazon-awssdk-integration-testing.gradle
+++ b/subprojects/micronaut-amazon-awssdk-integration-testing/micronaut-amazon-awssdk-integration-testing.gradle
@@ -17,6 +17,7 @@
  */
 dependencies {
     api group: 'org.testcontainers', name: 'localstack', version: testcontainersVersion
+    api group: 'org.ministack', name: 'testcontainers-ministack', version: ministackVersion
 
     compileOnly "software.amazon.awssdk:netty-nio-client:$awsSdk2Version"
 

--- a/subprojects/micronaut-amazon-awssdk-integration-testing/src/main/java/com/agorapulse/micronaut/amazon/awssdk/itest/ministack/MinistackContainerConfiguration.java
+++ b/subprojects/micronaut-amazon-awssdk-integration-testing/src/main/java/com/agorapulse/micronaut/amazon/awssdk/itest/ministack/MinistackContainerConfiguration.java
@@ -1,0 +1,112 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2018-2026 Agorapulse.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.agorapulse.micronaut.amazon.awssdk.itest.ministack;
+
+import io.micronaut.context.annotation.ConfigurationProperties;
+import io.micronaut.core.convert.format.MapFormat;
+import io.micronaut.core.naming.conventions.StringConvention;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@ConfigurationProperties("ministack")
+public class MinistackContainerConfiguration {
+
+    private String tag;
+    private boolean shared;
+    private String region;
+    private String accessKey;
+    private String secretKey;
+    private boolean persistence;
+    private boolean imdsV2Required;
+    private boolean realInfrastructure;
+    private Map<String, String> env = new HashMap<>();
+
+    public String getTag() {
+        return tag;
+    }
+
+    public void setTag(String tag) {
+        this.tag = tag;
+    }
+
+    public boolean isShared() {
+        return shared;
+    }
+
+    public void setShared(boolean shared) {
+        this.shared = shared;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public void setRegion(String region) {
+        this.region = region;
+    }
+
+    public String getAccessKey() {
+        return accessKey;
+    }
+
+    public void setAccessKey(String accessKey) {
+        this.accessKey = accessKey;
+    }
+
+    public String getSecretKey() {
+        return secretKey;
+    }
+
+    public void setSecretKey(String secretKey) {
+        this.secretKey = secretKey;
+    }
+
+    public boolean isPersistence() {
+        return persistence;
+    }
+
+    public void setPersistence(boolean persistence) {
+        this.persistence = persistence;
+    }
+
+    public boolean isImdsV2Required() {
+        return imdsV2Required;
+    }
+
+    public void setImdsV2Required(boolean imdsV2Required) {
+        this.imdsV2Required = imdsV2Required;
+    }
+
+    public boolean isRealInfrastructure() {
+        return realInfrastructure;
+    }
+
+    public void setRealInfrastructure(boolean realInfrastructure) {
+        this.realInfrastructure = realInfrastructure;
+    }
+
+    public Map<String, String> getEnv() {
+        return env;
+    }
+
+    public void setEnv(@MapFormat(keyFormat = StringConvention.RAW) Map<String, String> env) {
+        this.env = env;
+    }
+
+}

--- a/subprojects/micronaut-amazon-awssdk-integration-testing/src/main/java/com/agorapulse/micronaut/amazon/awssdk/itest/ministack/MinistackContainerHolder.java
+++ b/subprojects/micronaut-amazon-awssdk-integration-testing/src/main/java/com/agorapulse/micronaut/amazon/awssdk/itest/ministack/MinistackContainerHolder.java
@@ -1,0 +1,188 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2018-2026 Agorapulse.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.agorapulse.micronaut.amazon.awssdk.itest.ministack;
+
+import io.micronaut.core.util.StringUtils;
+import org.ministack.testcontainers.MiniStackContainer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.Closeable;
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
+
+public class MinistackContainerHolder implements Closeable {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MinistackContainerHolder.class);
+    private static final Map<String, GenericContainer<?>> SHARED_CONTAINERS = new ConcurrentHashMap<>();
+
+    private static MiniStackContainer sharedContainer;
+
+    private final Lock startLock = new ReentrantLock();
+    private final MinistackContainerConfiguration configuration;
+    private final Map<String, MinistackContainerOverridesConfiguration> overrides;
+    private final Map<String, GenericContainer<?>> containers = new ConcurrentHashMap<>();
+    private MiniStackContainer container;
+
+    public MinistackContainerHolder(
+        MinistackContainerConfiguration configuration,
+        List<MinistackContainerOverridesConfiguration> configurationOverrides
+    ) {
+        this.configuration = configuration;
+        this.overrides = configurationOverrides.isEmpty()
+            ? Collections.emptyMap()
+            : configurationOverrides.stream().collect(Collectors.toMap(
+                conf -> conf.getService().toUpperCase(Locale.ROOT),
+                conf -> conf
+            ));
+    }
+
+    public URI getEndpointOverride(String service) {
+        return requireRunningContainer(service);
+    }
+
+    @Override
+    public void close() {
+        if (container != null) {
+            LOGGER.info("Closing MiniStack container with tag {}", configuration.getTag());
+            container.close();
+            LOGGER.info("Closed MiniStack container with tag {}", configuration.getTag());
+        }
+        containers.forEach((service, genericContainer) -> {
+            LOGGER.info("Closing container {} for service {}", genericContainer.getDockerImageName(), service);
+            genericContainer.close();
+            LOGGER.info("Closed container {} for service {}", genericContainer.getDockerImageName(), service);
+        });
+    }
+
+    public URI requireRunningContainer(String service) {
+        String serviceKey = service.toUpperCase(Locale.ROOT);
+        MinistackContainerOverridesConfiguration configurationOverride = overrides.get(serviceKey);
+        if (configurationOverride != null) {
+            if (configurationOverride.isValid()) {
+                if (configurationOverride.isShared()) {
+                    GenericContainer<?> shared = SHARED_CONTAINERS.computeIfAbsent(
+                        serviceKey,
+                        s -> createAndStartGenericContainer(configurationOverride, s)
+                    );
+                    return URI.create("http://" + shared.getHost() + ":" + shared.getMappedPort(configurationOverride.getPort()));
+                }
+
+                GenericContainer<?> mock = containers.computeIfAbsent(
+                    serviceKey,
+                    s -> createAndStartGenericContainer(configurationOverride, s)
+                );
+                return URI.create("http://" + mock.getHost() + ":" + mock.getMappedPort(configurationOverride.getPort()));
+            } else {
+                LOGGER.warn(
+                    "Configuration for overriding service {} is not valid. Please, specify image, tag and port. Image: {}, Tag: {}, Port: {}",
+                    configurationOverride.getService(),
+                    configurationOverride.getImage(),
+                    configurationOverride.getTag(),
+                    configurationOverride.getPort()
+                );
+            }
+        }
+
+        if (configuration.isShared()) {
+            if (sharedContainer == null) {
+                sharedContainer = createAndStartMinistackContainer();
+            }
+            return URI.create(sharedContainer.getEndpoint());
+        }
+
+        if (container == null) {
+            container = createAndStartMinistackContainer();
+        }
+
+        return URI.create(container.getEndpoint());
+    }
+
+    private MiniStackContainer createAndStartMinistackContainer() {
+        startLock.lock();
+        try {
+            String tag = configuration.getTag();
+            LOGGER.info("Starting MiniStack container with tag {}", tag);
+            MiniStackContainer ministack = StringUtils.isNotEmpty(tag)
+                ? new MiniStackContainer(tag)
+                : new MiniStackContainer();
+
+            Map<String, String> env = new HashMap<>(configuration.getEnv());
+            if (StringUtils.isNotEmpty(configuration.getRegion())) {
+                env.putIfAbsent("MINISTACK_REGION", configuration.getRegion());
+            }
+            if (StringUtils.isNotEmpty(configuration.getAccessKey())) {
+                env.putIfAbsent("AWS_ACCESS_KEY_ID", configuration.getAccessKey());
+            }
+            if (StringUtils.isNotEmpty(configuration.getSecretKey())) {
+                env.putIfAbsent("AWS_SECRET_ACCESS_KEY", configuration.getSecretKey());
+            }
+            if (configuration.isPersistence()) {
+                env.putIfAbsent("PERSIST_STATE", "1");
+                env.putIfAbsent("S3_PERSIST", "1");
+            }
+            if (configuration.isImdsV2Required()) {
+                env.putIfAbsent("MINISTACK_IMDS_V2_REQUIRED", "1");
+            }
+            if (!env.isEmpty()) {
+                ministack.withEnv(env);
+            }
+            if (configuration.isRealInfrastructure()) {
+                ministack.withRealInfrastructure();
+            }
+
+            ministack.start();
+            LOGGER.info("Started MiniStack container with tag {}", tag);
+            return ministack;
+        } finally {
+            startLock.unlock();
+        }
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private GenericContainer createAndStartGenericContainer(MinistackContainerOverridesConfiguration configuration, String service) {
+        startLock.lock();
+        try {
+            String tag = configuration.getTag();
+            if (StringUtils.isEmpty(tag)) {
+                tag = "latest";
+            }
+            LOGGER.info("Starting container {}:{} for service {}", configuration.getImage(), tag, service);
+            DockerImageName dockerImageName = DockerImageName.parse(configuration.getImage()).withTag(tag);
+            GenericContainer container = new GenericContainer(dockerImageName)
+                .withEnv(configuration.getEnv())
+                .withExposedPorts(configuration.getPort());
+            container.start();
+            LOGGER.info("Started container {}:{} for service {}", configuration.getImage(), tag, service);
+            return container;
+        } finally {
+            startLock.unlock();
+        }
+    }
+
+}

--- a/subprojects/micronaut-amazon-awssdk-integration-testing/src/main/java/com/agorapulse/micronaut/amazon/awssdk/itest/ministack/MinistackContainerHolderFactory.java
+++ b/subprojects/micronaut-amazon-awssdk-integration-testing/src/main/java/com/agorapulse/micronaut/amazon/awssdk/itest/ministack/MinistackContainerHolderFactory.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.agorapulse.micronaut.amazon.awssdk.itest.localstack;
+package com.agorapulse.micronaut.amazon.awssdk.itest.ministack;
 
 import com.agorapulse.micronaut.amazon.awssdk.core.AwsConfiguration;
 import io.micronaut.context.annotation.Bean;
@@ -30,30 +30,29 @@ import java.util.List;
 
 @Factory
 @Replaces(AwsConfiguration.class)
-@Requires(missingProperty = "localstack.disabled")
-@Requires(property = "ministack.enabled", notEquals = "true")
-public class LocalstackContainerHolderFactory {
+@Requires(property = "ministack.enabled", value = "true")
+public class MinistackContainerHolderFactory {
 
     @Primary
     @Singleton
     @Bean(preDestroy = "close")
-    @Requires(property = "localstack.shared", notEquals = "true")
-    public LocalstackContainerHolder localstackContainerHolderLazy(
-        LocalstackContainerConfiguration configuration,
-        List<LocalstackContainerOverridesConfiguration> overrides
+    @Requires(property = "ministack.shared", notEquals = "true")
+    public MinistackContainerHolder ministackContainerHolderLazy(
+        MinistackContainerConfiguration configuration,
+        List<MinistackContainerOverridesConfiguration> overrides
     ) {
-        return new LocalstackContainerHolder(configuration, overrides);
+        return new MinistackContainerHolder(configuration, overrides);
     }
 
     @Primary
     @Context
     @Bean(preDestroy = "close")
-    @Requires(property = "localstack.shared", value = "true")
-    public LocalstackContainerHolder localstackContainerHolderEager(
-        LocalstackContainerConfiguration configuration,
-        List<LocalstackContainerOverridesConfiguration> overrides
+    @Requires(property = "ministack.shared", value = "true")
+    public MinistackContainerHolder ministackContainerHolderEager(
+        MinistackContainerConfiguration configuration,
+        List<MinistackContainerOverridesConfiguration> overrides
     ) {
-        return new LocalstackContainerHolder(configuration, overrides);
+        return new MinistackContainerHolder(configuration, overrides);
     }
 
 }

--- a/subprojects/micronaut-amazon-awssdk-integration-testing/src/main/java/com/agorapulse/micronaut/amazon/awssdk/itest/ministack/MinistackContainerOverridesConfiguration.java
+++ b/subprojects/micronaut-amazon-awssdk-integration-testing/src/main/java/com/agorapulse/micronaut/amazon/awssdk/itest/ministack/MinistackContainerOverridesConfiguration.java
@@ -1,0 +1,91 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2018-2026 Agorapulse.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.agorapulse.micronaut.amazon.awssdk.itest.ministack;
+
+import io.micronaut.context.annotation.EachProperty;
+import io.micronaut.context.annotation.Parameter;
+import io.micronaut.core.convert.format.MapFormat;
+import io.micronaut.core.naming.conventions.StringConvention;
+import io.micronaut.core.util.StringUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@EachProperty("ministack.containers")
+public class MinistackContainerOverridesConfiguration {
+
+    private final String service;
+    private String image;
+    private String tag;
+    private int port;
+    private boolean shared;
+    private Map<String, String> env = new HashMap<>();
+
+    public MinistackContainerOverridesConfiguration(@Parameter String name) {
+        this.service = name;
+    }
+
+    public String getService() {
+        return service;
+    }
+
+    public String getImage() {
+        return image;
+    }
+
+    public void setImage(String image) {
+        this.image = image;
+    }
+
+    public String getTag() {
+        return tag;
+    }
+
+    public void setTag(String tag) {
+        this.tag = tag;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+
+    public boolean isShared() {
+        return shared;
+    }
+
+    public void setShared(boolean shared) {
+        this.shared = shared;
+    }
+
+    public Map<String, String> getEnv() {
+        return env;
+    }
+
+    public void setEnv(@MapFormat(keyFormat = StringConvention.RAW) Map<String, String> env) {
+        this.env = env;
+    }
+
+    public boolean isValid() {
+        return StringUtils.isNotEmpty(image) && StringUtils.isNotEmpty(tag) && port > 0;
+    }
+
+}

--- a/subprojects/micronaut-amazon-awssdk-integration-testing/src/main/java/com/agorapulse/micronaut/amazon/awssdk/itest/ministack/MinistackService.java
+++ b/subprojects/micronaut-amazon-awssdk-integration-testing/src/main/java/com/agorapulse/micronaut/amazon/awssdk/itest/ministack/MinistackService.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2018-2026 Agorapulse.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.agorapulse.micronaut.amazon.awssdk.itest.ministack;
+
+public final class MinistackService {
+
+    public static final String S3 = "S3";
+    public static final String DYNAMODB = "DYNAMODB";
+    public static final String SNS = "SNS";
+    public static final String SQS = "SQS";
+    public static final String SES = "SES";
+    public static final String LAMBDA = "LAMBDA";
+    public static final String KINESIS = "KINESIS";
+    public static final String CLOUDWATCH = "CLOUDWATCH";
+    public static final String STS = "STS";
+
+    private MinistackService() {
+    }
+
+}

--- a/subprojects/micronaut-amazon-awssdk-integration-testing/src/main/java/com/agorapulse/micronaut/amazon/awssdk/itest/ministack/v2/cloudwatch/CloudWatchConfigurationListener.java
+++ b/subprojects/micronaut-amazon-awssdk-integration-testing/src/main/java/com/agorapulse/micronaut/amazon/awssdk/itest/ministack/v2/cloudwatch/CloudWatchConfigurationListener.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2018-2026 Agorapulse.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.agorapulse.micronaut.amazon.awssdk.itest.ministack.v2.cloudwatch;
+
+import com.agorapulse.micronaut.amazon.awssdk.cloudwatch.CloudWatchConfiguration;
+import com.agorapulse.micronaut.amazon.awssdk.itest.ministack.MinistackContainerHolder;
+import com.agorapulse.micronaut.amazon.awssdk.itest.ministack.MinistackService;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.event.BeanCreatedEvent;
+import io.micronaut.context.event.BeanCreatedEventListener;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+@Requires(classes = CloudWatchConfiguration.class, beans = MinistackContainerHolder.class)
+public class CloudWatchConfigurationListener implements BeanCreatedEventListener<CloudWatchConfiguration> {
+
+    private final MinistackContainerHolder holder;
+
+    public CloudWatchConfigurationListener(MinistackContainerHolder holder) {
+        this.holder = holder;
+    }
+
+    @Override
+    public CloudWatchConfiguration onCreated(BeanCreatedEvent<CloudWatchConfiguration> event) {
+        CloudWatchConfiguration conf = event.getBean();
+        if (conf.getEndpoint() != null) {
+            return conf;
+        }
+        conf.setEndpoint(holder.getEndpointOverride(MinistackService.CLOUDWATCH).toString());
+        return conf;
+    }
+
+}

--- a/subprojects/micronaut-amazon-awssdk-integration-testing/src/main/java/com/agorapulse/micronaut/amazon/awssdk/itest/ministack/v2/cloudwatchlogs/CloudWatchLogsConfigurationListener.java
+++ b/subprojects/micronaut-amazon-awssdk-integration-testing/src/main/java/com/agorapulse/micronaut/amazon/awssdk/itest/ministack/v2/cloudwatchlogs/CloudWatchLogsConfigurationListener.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2018-2026 Agorapulse.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.agorapulse.micronaut.amazon.awssdk.itest.ministack.v2.cloudwatchlogs;
+
+import com.agorapulse.micronaut.amazon.awssdk.cloudwatchlogs.CloudWatchLogsConfiguration;
+import com.agorapulse.micronaut.amazon.awssdk.itest.ministack.MinistackContainerHolder;
+import com.agorapulse.micronaut.amazon.awssdk.itest.ministack.MinistackService;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.event.BeanCreatedEvent;
+import io.micronaut.context.event.BeanCreatedEventListener;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+@Requires(classes = CloudWatchLogsConfiguration.class, beans = MinistackContainerHolder.class)
+public class CloudWatchLogsConfigurationListener implements BeanCreatedEventListener<CloudWatchLogsConfiguration> {
+
+    private final MinistackContainerHolder holder;
+
+    public CloudWatchLogsConfigurationListener(MinistackContainerHolder holder) {
+        this.holder = holder;
+    }
+
+    @Override
+    public CloudWatchLogsConfiguration onCreated(BeanCreatedEvent<CloudWatchLogsConfiguration> event) {
+        CloudWatchLogsConfiguration conf = event.getBean();
+        if (conf.getEndpoint() != null) {
+            return conf;
+        }
+        conf.setEndpoint(holder.getEndpointOverride(MinistackService.CLOUDWATCH).toString());
+        return conf;
+    }
+
+}

--- a/subprojects/micronaut-amazon-awssdk-integration-testing/src/main/java/com/agorapulse/micronaut/amazon/awssdk/itest/ministack/v2/dynamodb/DynamoDBConfigurationListener.java
+++ b/subprojects/micronaut-amazon-awssdk-integration-testing/src/main/java/com/agorapulse/micronaut/amazon/awssdk/itest/ministack/v2/dynamodb/DynamoDBConfigurationListener.java
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2018-2026 Agorapulse.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.agorapulse.micronaut.amazon.awssdk.itest.ministack.v2.dynamodb;
+
+import com.agorapulse.micronaut.amazon.awssdk.dynamodb.DynamoDBClientsFactory;
+import com.agorapulse.micronaut.amazon.awssdk.dynamodb.DynamoDBConfiguration;
+import com.agorapulse.micronaut.amazon.awssdk.itest.ministack.MinistackContainerHolder;
+import com.agorapulse.micronaut.amazon.awssdk.itest.ministack.MinistackService;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.event.BeanCreatedEvent;
+import io.micronaut.context.event.BeanCreatedEventListener;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+@Requires(classes = DynamoDBClientsFactory.class, beans = MinistackContainerHolder.class)
+public class DynamoDBConfigurationListener implements BeanCreatedEventListener<DynamoDBConfiguration> {
+
+    private final MinistackContainerHolder holder;
+
+    public DynamoDBConfigurationListener(MinistackContainerHolder holder) {
+        this.holder = holder;
+    }
+
+    @Override
+    public DynamoDBConfiguration onCreated(BeanCreatedEvent<DynamoDBConfiguration> event) {
+        DynamoDBConfiguration conf = event.getBean();
+        if (conf.getEndpoint() != null) {
+            return conf;
+        }
+        conf.setEndpoint(holder.getEndpointOverride(MinistackService.DYNAMODB).toString());
+        return conf;
+    }
+
+}

--- a/subprojects/micronaut-amazon-awssdk-integration-testing/src/main/java/com/agorapulse/micronaut/amazon/awssdk/itest/ministack/v2/kinesis/KinesisConfigurationListener.java
+++ b/subprojects/micronaut-amazon-awssdk-integration-testing/src/main/java/com/agorapulse/micronaut/amazon/awssdk/itest/ministack/v2/kinesis/KinesisConfigurationListener.java
@@ -1,0 +1,64 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2018-2026 Agorapulse.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.agorapulse.micronaut.amazon.awssdk.itest.ministack.v2.kinesis;
+
+import com.agorapulse.micronaut.amazon.awssdk.itest.ministack.MinistackContainerHolder;
+import com.agorapulse.micronaut.amazon.awssdk.itest.ministack.MinistackService;
+import com.agorapulse.micronaut.amazon.awssdk.kinesis.KinesisConfiguration;
+import com.agorapulse.micronaut.amazon.awssdk.kinesis.KinesisFactory;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.event.BeanCreatedEvent;
+import io.micronaut.context.event.BeanCreatedEventListener;
+import software.amazon.awssdk.core.SdkSystemSetting;
+
+import jakarta.inject.Singleton;
+import java.io.Closeable;
+
+@Singleton
+@Requires(classes = KinesisFactory.class, beans = MinistackContainerHolder.class)
+public class KinesisConfigurationListener implements BeanCreatedEventListener<KinesisConfiguration>, Closeable {
+
+    private final MinistackContainerHolder holder;
+    private final String oldCborValue;
+
+    public KinesisConfigurationListener(MinistackContainerHolder holder) {
+        this.holder = holder;
+        this.oldCborValue = System.getProperty(SdkSystemSetting.CBOR_ENABLED.property());
+        System.setProperty(SdkSystemSetting.CBOR_ENABLED.property(), "false");
+    }
+
+    @Override
+    public KinesisConfiguration onCreated(BeanCreatedEvent<KinesisConfiguration> event) {
+        KinesisConfiguration conf = event.getBean();
+        if (conf.getEndpoint() != null) {
+            return conf;
+        }
+        conf.setEndpoint(holder.getEndpointOverride(MinistackService.KINESIS).toString());
+        return conf;
+    }
+
+    @Override
+    public void close() {
+        if (oldCborValue == null) {
+            System.clearProperty(SdkSystemSetting.CBOR_ENABLED.property());
+        } else {
+            System.setProperty(SdkSystemSetting.CBOR_ENABLED.property(), oldCborValue);
+        }
+    }
+
+}

--- a/subprojects/micronaut-amazon-awssdk-integration-testing/src/main/java/com/agorapulse/micronaut/amazon/awssdk/itest/ministack/v2/lambda/LambdaConfigurationListener.java
+++ b/subprojects/micronaut-amazon-awssdk-integration-testing/src/main/java/com/agorapulse/micronaut/amazon/awssdk/itest/ministack/v2/lambda/LambdaConfigurationListener.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2018-2026 Agorapulse.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.agorapulse.micronaut.amazon.awssdk.itest.ministack.v2.lambda;
+
+import com.agorapulse.micronaut.amazon.awssdk.itest.ministack.MinistackContainerHolder;
+import com.agorapulse.micronaut.amazon.awssdk.itest.ministack.MinistackService;
+import com.agorapulse.micronaut.amazon.awssdk.lambda.LambdaConfiguration;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.event.BeanCreatedEvent;
+import io.micronaut.context.event.BeanCreatedEventListener;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+@Requires(classes = LambdaConfiguration.class, beans = MinistackContainerHolder.class)
+public class LambdaConfigurationListener implements BeanCreatedEventListener<LambdaConfiguration> {
+
+    private final MinistackContainerHolder holder;
+
+    public LambdaConfigurationListener(MinistackContainerHolder holder) {
+        this.holder = holder;
+    }
+
+    @Override
+    public LambdaConfiguration onCreated(BeanCreatedEvent<LambdaConfiguration> event) {
+        LambdaConfiguration conf = event.getBean();
+        if (conf.getEndpoint() != null) {
+            return conf;
+        }
+        conf.setEndpoint(holder.getEndpointOverride(MinistackService.LAMBDA).toString());
+        return conf;
+    }
+
+}

--- a/subprojects/micronaut-amazon-awssdk-integration-testing/src/main/java/com/agorapulse/micronaut/amazon/awssdk/itest/ministack/v2/s3/SimpleStorageServiceConfigurationListener.java
+++ b/subprojects/micronaut-amazon-awssdk-integration-testing/src/main/java/com/agorapulse/micronaut/amazon/awssdk/itest/ministack/v2/s3/SimpleStorageServiceConfigurationListener.java
@@ -1,0 +1,51 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2018-2026 Agorapulse.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.agorapulse.micronaut.amazon.awssdk.itest.ministack.v2.s3;
+
+import com.agorapulse.micronaut.amazon.awssdk.itest.ministack.MinistackContainerHolder;
+import com.agorapulse.micronaut.amazon.awssdk.itest.ministack.MinistackService;
+import com.agorapulse.micronaut.amazon.awssdk.s3.SimpleStorageServiceConfiguration;
+import com.agorapulse.micronaut.amazon.awssdk.s3.SimpleStorageServiceFactory;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.event.BeanCreatedEvent;
+import io.micronaut.context.event.BeanCreatedEventListener;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+@Requires(classes = SimpleStorageServiceFactory.class, beans = MinistackContainerHolder.class)
+public class SimpleStorageServiceConfigurationListener implements BeanCreatedEventListener<SimpleStorageServiceConfiguration> {
+
+    private final MinistackContainerHolder holder;
+
+    public SimpleStorageServiceConfigurationListener(MinistackContainerHolder holder) {
+        this.holder = holder;
+    }
+
+    @Override
+    public SimpleStorageServiceConfiguration onCreated(BeanCreatedEvent<SimpleStorageServiceConfiguration> event) {
+        SimpleStorageServiceConfiguration conf = event.getBean();
+        if (conf.getEndpoint() != null) {
+            return conf;
+        }
+        conf.setEndpoint(holder.getEndpointOverride(MinistackService.S3).toString());
+        conf.setForcePathStyle(true);
+        return conf;
+    }
+
+}

--- a/subprojects/micronaut-amazon-awssdk-integration-testing/src/main/java/com/agorapulse/micronaut/amazon/awssdk/itest/ministack/v2/ses/SimpleEmailServiceConfigurationListener.java
+++ b/subprojects/micronaut-amazon-awssdk-integration-testing/src/main/java/com/agorapulse/micronaut/amazon/awssdk/itest/ministack/v2/ses/SimpleEmailServiceConfigurationListener.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2018-2026 Agorapulse.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.agorapulse.micronaut.amazon.awssdk.itest.ministack.v2.ses;
+
+import com.agorapulse.micronaut.amazon.awssdk.itest.ministack.MinistackContainerHolder;
+import com.agorapulse.micronaut.amazon.awssdk.itest.ministack.MinistackService;
+import com.agorapulse.micronaut.amazon.awssdk.ses.SimpleEmailServiceConfiguration;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.event.BeanCreatedEvent;
+import io.micronaut.context.event.BeanCreatedEventListener;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+@Requires(classes = SimpleEmailServiceConfiguration.class, beans = MinistackContainerHolder.class)
+public class SimpleEmailServiceConfigurationListener implements BeanCreatedEventListener<SimpleEmailServiceConfiguration> {
+
+    private final MinistackContainerHolder holder;
+
+    public SimpleEmailServiceConfigurationListener(MinistackContainerHolder holder) {
+        this.holder = holder;
+    }
+
+    @Override
+    public SimpleEmailServiceConfiguration onCreated(BeanCreatedEvent<SimpleEmailServiceConfiguration> event) {
+        SimpleEmailServiceConfiguration conf = event.getBean();
+        if (conf.getEndpoint() != null) {
+            return conf;
+        }
+        conf.setEndpoint(holder.getEndpointOverride(MinistackService.SES).toString());
+        return conf;
+    }
+
+}

--- a/subprojects/micronaut-amazon-awssdk-integration-testing/src/main/java/com/agorapulse/micronaut/amazon/awssdk/itest/ministack/v2/sns/SimpleNotificationServiceConfigurationListener.java
+++ b/subprojects/micronaut-amazon-awssdk-integration-testing/src/main/java/com/agorapulse/micronaut/amazon/awssdk/itest/ministack/v2/sns/SimpleNotificationServiceConfigurationListener.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2018-2026 Agorapulse.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.agorapulse.micronaut.amazon.awssdk.itest.ministack.v2.sns;
+
+import com.agorapulse.micronaut.amazon.awssdk.itest.ministack.MinistackContainerHolder;
+import com.agorapulse.micronaut.amazon.awssdk.itest.ministack.MinistackService;
+import com.agorapulse.micronaut.amazon.awssdk.sns.SimpleNotificationServiceConfiguration;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.event.BeanCreatedEvent;
+import io.micronaut.context.event.BeanCreatedEventListener;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+@Requires(classes = SimpleNotificationServiceConfiguration.class, beans = MinistackContainerHolder.class)
+public class SimpleNotificationServiceConfigurationListener implements BeanCreatedEventListener<SimpleNotificationServiceConfiguration> {
+
+    private final MinistackContainerHolder holder;
+
+    public SimpleNotificationServiceConfigurationListener(MinistackContainerHolder holder) {
+        this.holder = holder;
+    }
+
+    @Override
+    public SimpleNotificationServiceConfiguration onCreated(BeanCreatedEvent<SimpleNotificationServiceConfiguration> event) {
+        SimpleNotificationServiceConfiguration conf = event.getBean();
+        if (conf.getEndpoint() != null) {
+            return conf;
+        }
+        conf.setEndpoint(holder.getEndpointOverride(MinistackService.SNS).toString());
+        return conf;
+    }
+
+}

--- a/subprojects/micronaut-amazon-awssdk-integration-testing/src/main/java/com/agorapulse/micronaut/amazon/awssdk/itest/ministack/v2/sqs/SimpleQueueServiceConfigurationListener.java
+++ b/subprojects/micronaut-amazon-awssdk-integration-testing/src/main/java/com/agorapulse/micronaut/amazon/awssdk/itest/ministack/v2/sqs/SimpleQueueServiceConfigurationListener.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2018-2026 Agorapulse.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.agorapulse.micronaut.amazon.awssdk.itest.ministack.v2.sqs;
+
+import com.agorapulse.micronaut.amazon.awssdk.itest.ministack.MinistackContainerHolder;
+import com.agorapulse.micronaut.amazon.awssdk.itest.ministack.MinistackService;
+import com.agorapulse.micronaut.amazon.awssdk.sqs.SimpleQueueServiceConfiguration;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.event.BeanCreatedEvent;
+import io.micronaut.context.event.BeanCreatedEventListener;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+@Requires(classes = SimpleQueueServiceConfiguration.class, beans = MinistackContainerHolder.class)
+public class SimpleQueueServiceConfigurationListener implements BeanCreatedEventListener<SimpleQueueServiceConfiguration> {
+
+    private final MinistackContainerHolder holder;
+
+    public SimpleQueueServiceConfigurationListener(MinistackContainerHolder holder) {
+        this.holder = holder;
+    }
+
+    @Override
+    public SimpleQueueServiceConfiguration onCreated(BeanCreatedEvent<SimpleQueueServiceConfiguration> event) {
+        SimpleQueueServiceConfiguration conf = event.getBean();
+        if (conf.getEndpoint() != null) {
+            return conf;
+        }
+        conf.setEndpoint(holder.getEndpointOverride(MinistackService.SQS).toString());
+        return conf;
+    }
+
+}

--- a/subprojects/micronaut-amazon-awssdk-integration-testing/src/main/java/com/agorapulse/micronaut/amazon/awssdk/itest/ministack/v2/sts/SecurityTokenServiceConfigurationListener.java
+++ b/subprojects/micronaut-amazon-awssdk-integration-testing/src/main/java/com/agorapulse/micronaut/amazon/awssdk/itest/ministack/v2/sts/SecurityTokenServiceConfigurationListener.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2018-2026 Agorapulse.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.agorapulse.micronaut.amazon.awssdk.itest.ministack.v2.sts;
+
+import com.agorapulse.micronaut.amazon.awssdk.itest.ministack.MinistackContainerHolder;
+import com.agorapulse.micronaut.amazon.awssdk.itest.ministack.MinistackService;
+import com.agorapulse.micronaut.amazon.awssdk.sts.SecurityTokenServiceConfiguration;
+import io.micronaut.context.annotation.Requires;
+import io.micronaut.context.event.BeanCreatedEvent;
+import io.micronaut.context.event.BeanCreatedEventListener;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+@Requires(classes = SecurityTokenServiceConfiguration.class, beans = MinistackContainerHolder.class)
+public class SecurityTokenServiceConfigurationListener implements BeanCreatedEventListener<SecurityTokenServiceConfiguration> {
+
+    private final MinistackContainerHolder holder;
+
+    public SecurityTokenServiceConfigurationListener(MinistackContainerHolder holder) {
+        this.holder = holder;
+    }
+
+    @Override
+    public SecurityTokenServiceConfiguration onCreated(BeanCreatedEvent<SecurityTokenServiceConfiguration> event) {
+        SecurityTokenServiceConfiguration conf = event.getBean();
+        if (conf.getEndpoint() != null) {
+            return conf;
+        }
+        conf.setEndpoint(holder.getEndpointOverride(MinistackService.STS).toString());
+        return conf;
+    }
+
+}

--- a/subprojects/micronaut-amazon-awssdk-integration-testing/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/itest/ministack/MinistackContainerConfigurationSpec.groovy
+++ b/subprojects/micronaut-amazon-awssdk-integration-testing/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/itest/ministack/MinistackContainerConfigurationSpec.groovy
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2018-2026 Agorapulse.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.agorapulse.micronaut.amazon.awssdk.itest.ministack
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.test.extensions.spock.annotation.MicronautTest
+import spock.lang.Specification
+
+import jakarta.inject.Inject
+
+@MicronautTest
+@Property(name = 'ministack.enabled', value = 'true')
+@Property(name = 'ministack.tag', value = 'latest')
+@Property(name = 'ministack.region', value = 'eu-west-1')
+@Property(name = 'ministack.access-key', value = 'my-key')
+@Property(name = 'ministack.secret-key', value = 'my-secret')
+@Property(name = 'ministack.persistence', value = 'true')
+@Property(name = 'ministack.env.MINISTACK_FOO', value = 'bar')
+@Property(name = 'ministack.env.LAMBDA_EXECUTOR', value = 'local')
+class MinistackContainerConfigurationSpec extends Specification {
+
+    @Inject MinistackContainerConfiguration configuration
+
+    void 'configuration is bound from ministack.* properties without hyphenating env keys'() {
+        expect:
+        configuration.tag == 'latest'
+        configuration.region == 'eu-west-1'
+        configuration.accessKey == 'my-key'
+        configuration.secretKey == 'my-secret'
+        configuration.persistence
+        configuration.env.get('MINISTACK_FOO') == 'bar'
+        configuration.env.get('LAMBDA_EXECUTOR') == 'local'
+    }
+
+}


### PR DESCRIPTION
## Summary
This PR adds comprehensive MiniStack integration testing support to the Micronaut AWS SDK integration testing module, providing a lightweight alternative to LocalStack for local AWS service testing.

## Key Changes

- **Core MiniStack Container Management**
  - Added `MinistackContainerHolder` to manage MiniStack container lifecycle with support for shared and per-test containers
  - Implemented `MinistackContainerConfiguration` for configurable MiniStack settings (tag, region, credentials, persistence, IMDSv2, real infrastructure)
  - Added `MinistackContainerOverridesConfiguration` to allow per-service container overrides with custom Docker images

- **Factory and Dependency Injection**
  - Created `MinistackContainerHolderFactory` to provide eager or lazy container initialization based on `ministack.shared` property
  - Factory replaces `AwsConfiguration` when `ministack.enabled=true`, disabling LocalStack automatically

- **Service-Specific Configuration Listeners**
  - Implemented `BeanCreatedEventListener` for all major AWS services:
    - S3, DynamoDB, SNS, SQS, SES, Lambda, Kinesis, CloudWatch, CloudWatch Logs, STS
  - Each listener automatically configures service endpoints to point to MiniStack containers
  - Special handling for Kinesis to disable CBOR encoding (not supported by MiniStack)
  - S3 listener enables path-style access for compatibility

- **Service Constants**
  - Added `MinistackService` enum-like class with constants for all supported services

- **Configuration and Documentation**
  - Updated Gradle dependencies to include MiniStack testcontainers library (v0.1.5)
  - Added documentation in DynamoDB guide explaining MiniStack setup and per-service container overrides
  - Added configuration test validating property binding without hyphenation for environment variables

## Notable Implementation Details

- Thread-safe container management using `ConcurrentHashMap` and `ReentrantLock`
- Support for both shared containers (across test runs) and isolated containers (per test)
- Per-service container override mechanism allowing substitution of specific services with custom Docker images
- Graceful resource cleanup via `Closeable` interface with proper logging
- Conditional bean creation based on presence of service factory classes to avoid errors when services aren't available

https://claude.ai/code/session_01YcKFXD1RKjGN7rmUEwtKXZ