### PR TITLE
Upgrade micronaut-aws-sdk to Micronaut 5.x

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,7 +1,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-# Copyright 2018-2023 Agorapulse.
+# Copyright 2018-2026 Agorapulse.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,14 +25,11 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GRADLE_OPTS: "-Xmx6g -Xms4g"
-      COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
+      - uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: zulu
-      - uses: gradle/actions/setup-gradle@v4
-      - run: |
-          ./gradlew check coveralls --parallel
+      - uses: gradle/actions/setup-gradle@v5
+      - run: ./gradlew check

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 25
           distribution: zulu
       - uses: gradle/actions/setup-gradle@v5
       - run: ./gradlew check

--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -10,10 +10,9 @@ jobs:
       GRADLE_OPTS: "-Xmx6g -Xms4g"
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
+      - uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 25
           distribution: zulu
       - name: Get Latest Release
         id: latest_version
@@ -21,6 +20,6 @@ jobs:
         with:
           owner: agorapulse
           repo: micronaut-aws-sdk
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@v5
       - name: Publish GitHub Pages
         run: ./gradlew gitPublishPush -x groovydoc -Pversion=${{ steps.latest_version.outputs.latest_tag }} -Prelease=true -Dorg.ajoberstar.grgit.auth.username=${{ secrets.AGORAPULSE_BOT_PERSONAL_TOKEN }}

--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -21,5 +21,12 @@ jobs:
           owner: agorapulse
           repo: micronaut-aws-sdk
       - uses: gradle/actions/setup-gradle@v5
+      - name: Configure git identity for gitPublishCommit
+        run: |
+          git config --global user.name 'Agorapulse Bot'
+          git config --global user.email 'oss@agorapulse.com'
       - name: Publish GitHub Pages
-        run: ./gradlew gitPublishPush -x groovydoc -Pversion=${{ steps.latest_version.outputs.latest_tag }} -Prelease=true -Dorg.ajoberstar.grgit.auth.username=${{ secrets.AGORAPULSE_BOT_PERSONAL_TOKEN }}
+        env:
+          GIT_PUBLISH_USERNAME: agorapulse-bot
+          GIT_PUBLISH_PASSWORD: ${{ secrets.AGORAPULSE_BOT_PERSONAL_TOKEN }}
+        run: ./gradlew gitPublishPush -x groovydoc -Pversion=${{ steps.latest_version.outputs.latest_tag }} -Prelease=true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,4 +52,4 @@ jobs:
           token: ${{ secrets.AGORAPULSE_BOT_PERSONAL_TOKEN }}
           repository: ${{ matrix.repository }}
           event-type: ap-new-version-released-event
-          client-payload: '{ "group": "com.agorapulse", "module": "micronaut-aws-sdk", "micronautCompatibility": [4], "version": "${{ github.ref_name }}", "property" : "micronaut.aws.sdk.version", "github" : ${{ toJson(github) }} }'
+          client-payload: '{ "group": "com.agorapulse", "module": "micronaut-aws-sdk", "micronautCompatibility": [5], "version": "${{ github.ref_name }}", "property" : "micronaut.aws.sdk.version", "github" : ${{ toJson(github) }} }'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,17 @@ jobs:
           fileName: 'secret.pgp'
           encodedString: ${{ secrets.SIGNING_SECRET_KEY_BASE64 }}
       - uses: gradle/actions/setup-gradle@v5
+      - name: Configure git identity for gitPublishCommit
+        run: |
+          git config --global user.name 'Agorapulse Bot'
+          git config --global user.email 'oss@agorapulse.com'
       - name: Release
         env:
           SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
           SIGNING_SECRET_KEY_PATH: ${{ steps.write_file.outputs.filePath }}
+          GIT_PUBLISH_USERNAME: agorapulse-bot
+          GIT_PUBLISH_PASSWORD: ${{ secrets.AGORAPULSE_BOT_PERSONAL_TOKEN }}
         run: ./gradlew gitPublishPush publishAndReleaseToMavenCentral "-Pversion=${{ github.ref_name }}" -PmavenCentralUsername=${{ secrets.MAVEN_CENTRAL_USERNAME }} -PmavenCentralPassword=${{ secrets.MAVEN_CENTRAL_PASSWORD }} -Prelease=true --stacktrace
   ping:
     if: ${{ !github.event.release.prerelease }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
           SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
           SIGNING_SECRET_KEY_PATH: ${{ steps.write_file.outputs.filePath }}
-        run: ./gradlew gitPublishPush publishAndReleaseToMavenCentral "-Pversion=${{ github.ref_name }}" -PmavenCentralUsername=${{ secrets.MAVEN_CENTRAL_USERNAME }} -PmavenCentralPassword=${{ secrets.MAVEN_CENTRAL_PASSWORD }} -Prelease=true "-Dorg.ajoberstar.grgit.auth.username=${{ secrets.AGORAPULSE_BOT_PERSONAL_TOKEN }}" --stacktrace
+        run: ./gradlew gitPublishPush publishAndReleaseToMavenCentral "-Pversion=${{ github.ref_name }}" -PmavenCentralUsername=${{ secrets.MAVEN_CENTRAL_USERNAME }} -PmavenCentralPassword=${{ secrets.MAVEN_CENTRAL_PASSWORD }} -Prelease=true --stacktrace
   ping:
     if: ${{ !github.event.release.prerelease }}
     name: Notify Upstream Repositories

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
           SIGNING_SECRET_KEY_PATH: ${{ steps.write_file.outputs.filePath }}
         run: ./gradlew gitPublishPush publishAndReleaseToMavenCentral "-Pversion=${{ github.ref_name }}" -PmavenCentralUsername=${{ secrets.MAVEN_CENTRAL_USERNAME }} -PmavenCentralPassword=${{ secrets.MAVEN_CENTRAL_PASSWORD }} -Prelease=true "-Dorg.ajoberstar.grgit.auth.username=${{ secrets.AGORAPULSE_BOT_PERSONAL_TOKEN }}" --stacktrace
   ping:
+    if: ${{ !github.event.release.prerelease }}
     name: Notify Upstream Repositories
     runs-on: ubuntu-latest
     needs: [release]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,9 @@ jobs:
       GRADLE_OPTS: "-Xmx6g -Xms4g"
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
+      - uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 25
           distribution: zulu
       - name: Decode PGP
         id: write_file
@@ -22,7 +21,7 @@ jobs:
         with:
           fileName: 'secret.pgp'
           encodedString: ${{ secrets.SIGNING_SECRET_KEY_BASE64 }}
-      - uses: gradle/actions/setup-gradle@v4
+      - uses: gradle/actions/setup-gradle@v5
       - name: Release
         env:
           SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}

--- a/README.adoc
+++ b/README.adoc
@@ -3,7 +3,6 @@
 --
 image::https://img.shields.io/maven-central/v/com.agorapulse/micronaut-amazon-awssdk-dynamodb.svg?label=Maven%20Central[link="https://search.maven.org/search?q=g:%22com.agorapulse%22%20AND%20a:%22micronaut-amazon-awssdk-dynamodb%22",float="left"]
 image::https://github.com/agorapulse/micronaut-aws-sdk/workflows/Check/badge.svg["Build Status", link="https://github.com/agorapulse/micronaut-aws-sdk/actions?query=workflow%3ACheck"float="left"]
-image::https://coveralls.io/repos/github/agorapulse/micronaut-aws-sdk/badge.svg?branch=master[link=https://coveralls.io/github/agorapulse/micronaut-aws-sdk?branch=master",float="left"]
 --
 
 '''

--- a/benchmarks/micronaut-amazon-awssdk-dynamodb-benchmarks/micronaut-amazon-awssdk-dynamodb-benchmarks.gradle
+++ b/benchmarks/micronaut-amazon-awssdk-dynamodb-benchmarks/micronaut-amazon-awssdk-dynamodb-benchmarks.gradle
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 plugins {
-    id "me.champeau.jmh" version "0.6.6"
+    id 'me.champeau.jmh' version '0.7.3'
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -16,220 +16,121 @@
  * limitations under the License.
  */
 plugins {
-    id 'org.kordamp.gradle.groovy-project'
-    id 'org.kordamp.gradle.checkstyle'
-    id 'org.kordamp.gradle.codenarc'
-    id 'org.kordamp.gradle.coveralls'
+    id 'lifecycle-base'
 }
 
-if (!project.hasProperty('mavenCentralUsername'))       ext.mavenCentralUsername            = System.getenv('MAVEN_CENTRAL_USERNAME') ?: '**UNDEFINED**'
-if (!project.hasProperty('mavenCentralPassword'))       ext.mavenCentralPassword            = System.getenv('MAVEN_CENTRAL_PASSWORD') ?: '**UNDEFINED**'
-if (!project.hasProperty('signingInMemoryKeyId'))       ext.signingInMemoryKeyId            = System.getenv('SIGNING_KEY_ID') ?: '**UNDEFINED**'
-if (!project.hasProperty('signingInMemoryKeyPassword')) ext.signingInMemoryKeyPassword      = System.getenv('SIGNING_PASSWORD') ?: '**UNDEFINED**'
-if (!project.hasProperty('signingInMemoryKey'))         ext.signingInMemoryKey              = System.getenv('SIGNING_SECRET_KEY_PATH') ? rootProject.file(System.getenv('SIGNING_SECRET_KEY_PATH')).text : '**UNDEFINED**'
-
-
-config {
-    release = (rootProject.findProperty('release') ?: false).toBoolean()
-
-    info {
-        name        = 'Micronaut Libraries'
-        vendor      = 'Agorapulse'
-        description = 'Set of useful libraries for Micronaut'
-
-        links {
-            website      = "https://github.com/${slug}"
-            issueTracker = "https://github.com/${slug}/issues"
-            scm          = "https://github.com/${slug}.git"
-        }
-
-        people {
-            person {
-                id    = 'musketyr'
-                name  = 'Vladimir Orany'
-                roles = ['developer']
-            }
-        }
-
-        repositories {
-            repository {
-                name = 'localRelease'
-                url  = "${project.rootProject.buildDir}/repos/local/release"
-            }
-            repository {
-                name = 'localSnapshot'
-                url  = "${project.rootProject.buildDir}/repos/local/snapshot"
-            }
-        }
-    }
-
-    licensing {
-        licenses {
-            license {
-                id = 'Apache-2.0'
-            }
-        }
-    }
-
-    publishing {
-        enabled = false
-        signing {
-            enabled = false
-        }
-    }
-
-    artifacts {
-        source {
-            enabled = false
-        }
-    }
-
-    quality {
-        checkstyle {
-            toolVersion = '8.27'
-        }
-
-        codenarc {
-            toolVersion = '1.5'
-        }
-    }
-
-    docs {
-        javadoc {
-            enabled = false
-            autoLinks {
-                enabled = false
-            }
-            aggregate {
-                enabled = false
-            }
-        }
-        groovydoc {
-            enabled = false
-            aggregate {
-                enabled = false
-            }
-        }
-    }
-
-}
-
+if (!project.hasProperty('mavenCentralUsername'))       ext.mavenCentralUsername       = System.getenv('MAVEN_CENTRAL_USERNAME') ?: '**UNDEFINED**'
+if (!project.hasProperty('mavenCentralPassword'))       ext.mavenCentralPassword       = System.getenv('MAVEN_CENTRAL_PASSWORD') ?: '**UNDEFINED**'
+if (!project.hasProperty('signingInMemoryKeyId'))       ext.signingInMemoryKeyId       = System.getenv('SIGNING_KEY_ID') ?: '**UNDEFINED**'
+if (!project.hasProperty('signingInMemoryKeyPassword')) ext.signingInMemoryKeyPassword = System.getenv('SIGNING_PASSWORD') ?: '**UNDEFINED**'
+if (!project.hasProperty('signingInMemoryKey'))         ext.signingInMemoryKey         = System.getenv('SIGNING_SECRET_KEY_PATH') ? rootProject.file(System.getenv('SIGNING_SECRET_KEY_PATH')).text : '**UNDEFINED**'
 
 allprojects {
     repositories {
         mavenCentral()
         maven { url 'https://repo.spring.io/release' }
     }
-
-    license {
-        exclude '**/*.json'
-        exclude '***.yml'
-        exclude 'logback.xml'
-    }
 }
 
-gradleProjects {
-    subprojects {
-        dirs(['subprojects', 'platforms']) {
-            mavenPublishing {
-                publishToMavenCentral(true)
-                signAllPublications()
-
-                pom {
-                    name = "Micronaut AWS SDK"
-                    description = 'Set of useful libraries for Micronaut'
-                    inceptionYear = "2018"
-                    url = "https://github.com/${slug}"
-                    licenses {
-                        license {
-                            name = "The Apache License, Version 2.0"
-                            url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
-                            distribution = "https://www.apache.org/licenses/LICENSE-2.0.txt"
-                        }
-                    }
-                    developers {
-                        developer {
-                            id = "musketyr"
-                            name = "Vladimir Orany"
-                            url = "https://github.com/musketyr/"
-                        }
-                    }
-                    scm {
-                        url = "https://github.com/${slug}.git"
-                        connection = "scm:git:git://github.com/${slug}.git"
-                        developerConnection = "scm:git:ssh://git@github.com/${slug}.git"
-                    }
-                }
+subprojects {
+    plugins.withId('com.agorapulse.gradle.micronaut-library') {
+        micronaut {
+            if (project.hasProperty('importMicronautPlatform')) {
+                importMicronautPlatform = true
             }
-
-            signing {
-                useInMemoryPgpKeys(rootProject.ext.signingInMemoryKey, rootProject.ext.signingInMemoryKeyPassword)
-                sign publishing.publications
+            testRuntime 'spock'
+            processing {
+                incremental false
             }
-        }
-
-        dirs(['subprojects', 'benchmarks']) { Project subproject ->
-            micronaut {
-                if (it.hasProperty('importMicronautPlatform')) {
-                    importMicronautPlatform = true
-                } else {
-                    project.logger.lifecycle "No importMicronautPlatform property found for ${micronaut.dump()}"
-                }
-                testRuntime 'spock'
-                processing {
-                    incremental false
-                }
-            }
-
-            dependencies {
-                api platform(project(':micronaut-aws-sdk-dependencies'))
-
-                compileOnly "org.apache.groovy:groovy:$groovyVersion"
-                compileOnly 'io.micronaut.aws:micronaut-aws-sdk-v2'
-                testImplementation "org.apache.groovy:groovy:$groovyVersion"
-                testImplementation 'io.micronaut.aws:micronaut-aws-sdk-v2'
-
-                implementation 'io.micronaut:micronaut-inject'
-                implementation 'io.micronaut:micronaut-runtime'
-
-
-                testAnnotationProcessor 'io.micronaut:micronaut-inject-java'
-
-                testImplementation 'io.micronaut:micronaut-inject-groovy'
-
-                testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
-                testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
-
-
-                testImplementation 'io.micronaut.test:micronaut-test-junit5'
-                testImplementation 'io.micronaut.test:micronaut-test-spock'
-
-                testRuntimeOnly 'ch.qos.logback:logback-classic:1.2.3'
-                testRuntimeOnly 'org.yaml:snakeyaml'
-            }
-
-            compileJava.options.compilerArgs += '-parameters'
-            compileTestJava.options.compilerArgs += '-parameters'
-
-            test {
-                useJUnitPlatform()
-                environment 'AWS_CBOR_DISABLE', 'true'
-                systemProperty 'TEST_RESOURCES_FOLDER', new File(subproject.projectDir, 'src/test/resources').canonicalPath
-                systemProperty 'user.timezone', 'UTC'
-                systemProperty 'user.language', 'en'
-            }
-
-            task cleanOut(type: Delete) {
-                delete file('out')
-            }
-
-            clean.dependsOn cleanOut
-        }
-
-        dirs(['subprojects', 'kotlin-libs']) { Project subproject ->
-            project(':micronaut-aws-sdk-bom').dependencies.constraints.api subproject
         }
     }
 }
 
-check.dependsOn('aggregateCheckstyle', 'aggregateCodenarc', 'aggregateAllTestReports', 'coveralls')
+configure(subprojects.findAll { it.projectDir.parentFile?.name in ['subprojects', 'platforms', 'kotlin-libs'] }) { Project sub ->
+    sub.mavenPublishing {
+        publishToMavenCentral(true)
+        signAllPublications()
+
+        pom {
+            name = sub.name
+            description = 'Micronaut AWS SDK'
+            inceptionYear = '2018'
+            url = "https://github.com/${rootProject.slug}"
+            licenses {
+                license {
+                    name = 'The Apache Software License, Version 2.0'
+                    url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
+                    distribution = 'repo'
+                }
+            }
+            developers {
+                developer {
+                    id = 'musketyr'
+                    name = 'Vladimir Orany'
+                    url = 'https://github.com/musketyr/'
+                }
+            }
+            scm {
+                url = "https://github.com/${rootProject.slug}"
+                connection = "scm:git:https://github.com/${rootProject.slug}.git"
+                developerConnection = "scm:git:git@github.com:${rootProject.slug}.git"
+            }
+            issueManagement {
+                system = 'GitHub'
+                url = "https://github.com/${rootProject.slug}/issues"
+            }
+        }
+    }
+
+    sub.signing {
+        useInMemoryPgpKeys(rootProject.ext.signingInMemoryKey, rootProject.ext.signingInMemoryKeyPassword)
+        sign publishing.publications
+    }
+}
+
+configure(subprojects.findAll { it.projectDir.parentFile?.name in ['subprojects', 'benchmarks'] }) { Project subproject ->
+    dependencies {
+        api platform(project(':micronaut-aws-sdk-dependencies'))
+
+        compileOnly "org.apache.groovy:groovy:$groovyVersion"
+        compileOnly 'io.micronaut.aws:micronaut-aws-sdk-v2'
+        testImplementation "org.apache.groovy:groovy:$groovyVersion"
+        testImplementation 'io.micronaut.aws:micronaut-aws-sdk-v2'
+
+        implementation 'io.micronaut:micronaut-inject'
+        implementation 'io.micronaut:micronaut-runtime'
+
+        testAnnotationProcessor 'io.micronaut:micronaut-inject-java'
+
+        testImplementation 'io.micronaut:micronaut-inject-groovy'
+
+        testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
+        testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
+
+        testImplementation 'io.micronaut.test:micronaut-test-junit5'
+        testImplementation 'io.micronaut.test:micronaut-test-spock'
+
+        testRuntimeOnly 'ch.qos.logback:logback-classic:1.2.3'
+        testRuntimeOnly 'org.yaml:snakeyaml'
+    }
+
+    compileJava.options.compilerArgs += '-parameters'
+    compileTestJava.options.compilerArgs += '-parameters'
+
+    test {
+        useJUnitPlatform()
+        environment 'AWS_CBOR_DISABLE', 'true'
+        systemProperty 'TEST_RESOURCES_FOLDER', new File(subproject.projectDir, 'src/test/resources').canonicalPath
+        systemProperty 'user.timezone', 'UTC'
+        systemProperty 'user.language', 'en'
+    }
+
+    tasks.register('cleanOut', Delete) {
+        delete file('out')
+    }
+    clean.dependsOn cleanOut
+}
+
+configure(subprojects.findAll { it.projectDir.parentFile?.name in ['subprojects', 'kotlin-libs'] }) { Project subproject ->
+    project(':micronaut-aws-sdk-bom').dependencies.constraints.api subproject
+}

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 plugins {
-    id 'lifecycle-base'
+    id 'com.agorapulse.gradle.root-project'
 }
 
 if (!project.hasProperty('mavenCentralUsername'))       ext.mavenCentralUsername       = System.getenv('MAVEN_CENTRAL_USERNAME') ?: '**UNDEFINED**'
@@ -32,114 +32,114 @@ allprojects {
     }
 }
 
-subprojects {
-    plugins.withType(JavaPlugin) {
-        java {
-            toolchain {
-                languageVersion = JavaLanguageVersion.of(javaVersion as int)
-            }
-        }
-    }
-
-    plugins.withId('com.agorapulse.gradle.micronaut-library') {
-        micronaut {
-            if (project.hasProperty('importMicronautPlatform')) {
-                importMicronautPlatform = true
-            }
-            testRuntime 'spock'
-            processing {
-                incremental false
-            }
-        }
-    }
-}
-
-configure(subprojects.findAll { it.projectDir.parentFile?.name in ['subprojects', 'platforms', 'kotlin-libs'] }) { Project sub ->
-    sub.mavenPublishing {
-        publishToMavenCentral(true)
-        signAllPublications()
-
-        pom {
-            name = sub.name
-            description = 'Micronaut AWS SDK'
-            inceptionYear = '2018'
-            url = "https://github.com/${rootProject.slug}"
-            licenses {
-                license {
-                    name = 'The Apache Software License, Version 2.0'
-                    url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
-                    distribution = 'repo'
+gradleProjects {
+    subprojects {
+        dirs(['subprojects', 'kotlin-libs', 'benchmarks']) {
+            java {
+                toolchain {
+                    languageVersion = JavaLanguageVersion.of(javaVersion as int)
                 }
             }
-            developers {
-                developer {
-                    id = 'musketyr'
-                    name = 'Vladimir Orany'
-                    url = 'https://github.com/musketyr/'
+
+            micronaut {
+                if (project.hasProperty('importMicronautPlatform')) {
+                    importMicronautPlatform = true
+                }
+                testRuntime 'spock'
+                processing {
+                    incremental false
                 }
             }
-            scm {
-                url = "https://github.com/${rootProject.slug}"
-                connection = "scm:git:https://github.com/${rootProject.slug}.git"
-                developerConnection = "scm:git:git@github.com:${rootProject.slug}.git"
+        }
+
+        dirs(['subprojects', 'platforms', 'kotlin-libs']) {
+            mavenPublishing {
+                publishToMavenCentral(true)
+                signAllPublications()
+
+                pom {
+                    name = project.name
+                    description = 'Micronaut AWS SDK'
+                    inceptionYear = '2018'
+                    url = "https://github.com/${rootProject.slug}"
+                    licenses {
+                        license {
+                            name = 'The Apache Software License, Version 2.0'
+                            url = 'https://www.apache.org/licenses/LICENSE-2.0.txt'
+                            distribution = 'repo'
+                        }
+                    }
+                    developers {
+                        developer {
+                            id = 'musketyr'
+                            name = 'Vladimir Orany'
+                            url = 'https://github.com/musketyr/'
+                        }
+                    }
+                    scm {
+                        url = "https://github.com/${rootProject.slug}"
+                        connection = "scm:git:https://github.com/${rootProject.slug}.git"
+                        developerConnection = "scm:git:git@github.com:${rootProject.slug}.git"
+                    }
+                    issueManagement {
+                        system = 'GitHub'
+                        url = "https://github.com/${rootProject.slug}/issues"
+                    }
+                }
             }
-            issueManagement {
-                system = 'GitHub'
-                url = "https://github.com/${rootProject.slug}/issues"
+
+            signing {
+                useInMemoryPgpKeys(rootProject.ext.signingInMemoryKey, rootProject.ext.signingInMemoryKeyPassword)
+                sign publishing.publications
             }
         }
+
+        dirs(['subprojects', 'benchmarks']) {
+            dependencies {
+                api platform(project(':micronaut-aws-sdk-dependencies'))
+
+                compileOnly "org.apache.groovy:groovy:$groovyVersion"
+                compileOnly 'io.micronaut.aws:micronaut-aws-sdk-v2'
+                testImplementation "org.apache.groovy:groovy:$groovyVersion"
+                testImplementation 'io.micronaut.aws:micronaut-aws-sdk-v2'
+
+                implementation 'io.micronaut:micronaut-inject'
+                implementation 'io.micronaut:micronaut-runtime'
+
+                testAnnotationProcessor 'io.micronaut:micronaut-inject-java'
+
+                testImplementation 'io.micronaut:micronaut-inject-groovy'
+
+                testImplementation "org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion"
+                testImplementation "org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion"
+
+                testImplementation 'io.micronaut.test:micronaut-test-junit5'
+                testImplementation 'io.micronaut.test:micronaut-test-spock'
+                testImplementation "org.spockframework:spock-core:$spockVersion"
+
+                testRuntimeOnly 'ch.qos.logback:logback-classic:1.2.3'
+                testRuntimeOnly 'org.yaml:snakeyaml'
+            }
+
+            compileJava.options.compilerArgs += '-parameters'
+            compileTestJava.options.compilerArgs += '-parameters'
+
+            test {
+                useJUnitPlatform()
+                environment 'AWS_CBOR_DISABLE', 'true'
+                systemProperty 'TEST_RESOURCES_FOLDER', new File(projectDir, 'src/test/resources').canonicalPath
+                systemProperty 'user.timezone', 'UTC'
+                systemProperty 'user.language', 'en'
+            }
+
+            tasks.register('cleanOut', Delete) {
+                delete file('out')
+            }
+            clean.dependsOn cleanOut
+        }
+
+        dirs(['subprojects', 'kotlin-libs']) {
+            rootProject.project(':micronaut-aws-sdk-bom').dependencies.constraints.api project
+        }
     }
-
-    sub.signing {
-        useInMemoryPgpKeys(rootProject.ext.signingInMemoryKey, rootProject.ext.signingInMemoryKeyPassword)
-        sign publishing.publications
-    }
-}
-
-configure(subprojects.findAll { it.projectDir.parentFile?.name in ['subprojects', 'benchmarks'] }) { Project subproject ->
-    dependencies {
-        api platform(project(':micronaut-aws-sdk-dependencies'))
-
-        compileOnly "org.apache.groovy:groovy:$groovyVersion"
-        compileOnly 'io.micronaut.aws:micronaut-aws-sdk-v2'
-        testImplementation "org.apache.groovy:groovy:$groovyVersion"
-        testImplementation 'io.micronaut.aws:micronaut-aws-sdk-v2'
-
-        implementation 'io.micronaut:micronaut-inject'
-        implementation 'io.micronaut:micronaut-runtime'
-
-        testAnnotationProcessor 'io.micronaut:micronaut-inject-java'
-
-        testImplementation 'io.micronaut:micronaut-inject-groovy'
-
-        testImplementation "org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion"
-        testImplementation "org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion"
-
-        testImplementation 'io.micronaut.test:micronaut-test-junit5'
-        testImplementation 'io.micronaut.test:micronaut-test-spock'
-        testImplementation "org.spockframework:spock-core:$spockVersion"
-
-        testRuntimeOnly 'ch.qos.logback:logback-classic:1.2.3'
-        testRuntimeOnly 'org.yaml:snakeyaml'
-    }
-
-    compileJava.options.compilerArgs += '-parameters'
-    compileTestJava.options.compilerArgs += '-parameters'
-
-    test {
-        useJUnitPlatform()
-        environment 'AWS_CBOR_DISABLE', 'true'
-        systemProperty 'TEST_RESOURCES_FOLDER', new File(subproject.projectDir, 'src/test/resources').canonicalPath
-        systemProperty 'user.timezone', 'UTC'
-        systemProperty 'user.language', 'en'
-    }
-
-    tasks.register('cleanOut', Delete) {
-        delete file('out')
-    }
-    clean.dependsOn cleanOut
-}
-
-configure(subprojects.findAll { it.projectDir.parentFile?.name in ['subprojects', 'kotlin-libs'] }) { Project subproject ->
-    project(':micronaut-aws-sdk-bom').dependencies.constraints.api subproject
 }

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,14 @@ allprojects {
 }
 
 subprojects {
+    plugins.withType(JavaPlugin) {
+        java {
+            toolchain {
+                languageVersion = JavaLanguageVersion.of(javaVersion as int)
+            }
+        }
+    }
+
     plugins.withId('com.agorapulse.gradle.micronaut-library') {
         micronaut {
             if (project.hasProperty('importMicronautPlatform')) {
@@ -104,11 +112,12 @@ configure(subprojects.findAll { it.projectDir.parentFile?.name in ['subprojects'
 
         testImplementation 'io.micronaut:micronaut-inject-groovy'
 
-        testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
-        testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
+        testImplementation "org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion"
+        testImplementation "org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion"
 
         testImplementation 'io.micronaut.test:micronaut-test-junit5'
         testImplementation 'io.micronaut.test:micronaut-test-spock'
+        testImplementation "org.spockframework:spock-core:$spockVersion"
 
         testRuntimeOnly 'ch.qos.logback:logback-classic:1.2.3'
         testRuntimeOnly 'org.yaml:snakeyaml'

--- a/docs/guide/guide.gradle
+++ b/docs/guide/guide.gradle
@@ -20,6 +20,14 @@ plugins {
     id 'org.ajoberstar.git-publish' version "$gitPublishPluginVersion"
 }
 
+// gradle-git-publish 5.x no longer reads GRGIT_USER / GRGIT_PASS env vars
+// (or the org.ajoberstar.grgit.auth.* system properties). HTTPS push
+// credentials must be set on the gitPublish extension directly.
+gitPublish {
+    username = providers.environmentVariable('GIT_PUBLISH_USERNAME').orElse('')
+    password = providers.environmentVariable('GIT_PUBLISH_PASSWORD').orElse('')
+}
+
 configurations {
     asciidoctorExtensions
 }

--- a/docs/guide/guide.gradle
+++ b/docs/guide/guide.gradle
@@ -17,7 +17,6 @@
  */
 plugins {
     id 'com.agorapulse.gradle.guide'
-    id 'org.ajoberstar.git-publish' version "$gitPublishPluginVersion"
 }
 
 // gradle-git-publish 5.x no longer reads GRGIT_USER / GRGIT_PASS env vars

--- a/docs/guide/guide.gradle
+++ b/docs/guide/guide.gradle
@@ -15,27 +15,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath("org.ajoberstar.grgit:grgit-core:$grgitVersion")
-    }
-}
 plugins {
-    id 'org.kordamp.gradle.guide'
-    id 'org.ajoberstar.git-publish'
-}
-
-config {
-    docs {
-        guide {
-            publish {
-                enabled = true
-            }
-        }
-    }
+    id 'com.agorapulse.gradle.guide'
+    id 'org.ajoberstar.git-publish' version "$gitPublishPluginVersion"
 }
 
 configurations {
@@ -57,5 +39,4 @@ asciidoctor {
         'root-dir': rootDir,
         'project-slug': slug
     ]
-
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,19 +16,27 @@
 # limitations under the License.
 #
 
+org.gradle.caching=true
+
 slug=agorapulse/micronaut-aws-sdk
 group=com.agorapulse
+
+javaVersion = 25
+
+agorapulseGradlePluginsVersion = 4.4.2
+mavenCentralPublishPluginVersion = 0.34.0
+develocityPluginVersion = 4.2.2
+gitPublishPluginVersion = 2.1.3
+
 micronautVersion = 4.2.0
 micronautGradlePluginVersion = 4.2.0
+
 gruVersion = 2.2.0
 awsSdk2Version = 2.41.16
 awsLambdaRuntimeVersion=2.5.0
 awsLambdaEventsVersion=3.16.1
 testcontainersVersion = 1.17.3
 ministackVersion = 0.1.5
-kordampVersion=0.53.0
-gitPublishPluginVersion=2.1.3
-mavenCentralPublishPluginVersion=0.34.0
 closureSupportVersion=0.6.3
 mockitoVersion=2.23.4
 kotlinVersion=1.9.21
@@ -54,4 +62,3 @@ projectReactorVersion = 3.8.2
 
 # awaitility version
 awaitilityVersion = 4.2.0
-

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,28 +28,30 @@ mavenCentralPublishPluginVersion = 0.34.0
 develocityPluginVersion = 4.2.2
 gitPublishPluginVersion = 2.1.3
 
-micronautVersion = 4.2.0
-micronautGradlePluginVersion = 4.2.0
+micronautVersion = 5.0.0
+micronautGradlePluginVersion = 5.0.0
 
 gruVersion = 2.2.0
 awsSdk2Version = 2.41.16
 awsLambdaRuntimeVersion=2.5.0
 awsLambdaEventsVersion=3.16.1
-testcontainersVersion = 1.17.3
+testcontainersVersion = 1.21.4
 ministackVersion = 0.1.5
 closureSupportVersion=0.6.3
-mockitoVersion=2.23.4
-kotlinVersion=1.9.21
-kspVersion=1.9.21-1.0.15
+mockitoVersion=5.23.0
+kotlinVersion=2.3.21
+kspVersion=2.3.7
 grgitVersion=5.0.0
 opencsvVersion=5.12.0
+junitJupiterVersion=6.0.3
+spockVersion=2.4-groovy-5.0
 
 # other versions creates conflicts in Groovydoc
-groovyVersion = 4.0.16
+groovyVersion = 5.0.0
 
 # this should be aligned to Micronaut version
 # required for AWS CBOR marshalling
-jackson.datatype.version=2.9.7
+jackson.datatype.version=3.0.0
 
 # kinesis client version
 kinesisClientV2Version=2.7.2

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Thu Apr 09 06:59:57 CEST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/kotlin-libs/micronaut-amazon-awssdk-dynamodb-kotlin/micronaut-amazon-awssdk-dynamodb-kotlin.gradle
+++ b/kotlin-libs/micronaut-amazon-awssdk-dynamodb-kotlin/micronaut-amazon-awssdk-dynamodb-kotlin.gradle
@@ -32,8 +32,8 @@ dependencies {
     implementation 'io.micronaut:micronaut-runtime'
 
     testImplementation 'io.micronaut.test:micronaut-test-junit5'
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
-    testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
+    testImplementation "org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion"
+    testImplementation "org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion"
 
     testImplementation "io.projectreactor:reactor-core:$projectReactorVersion"
 

--- a/kotlin-libs/micronaut-amazon-awssdk-dynamodb-kotlin/src/test/kotlin/com/agorapulse/micronaut/amazon/awssdk/dynamodb/kotlin/DeclarativeServiceTest.kt
+++ b/kotlin-libs/micronaut-amazon-awssdk-dynamodb-kotlin/src/test/kotlin/com/agorapulse/micronaut/amazon/awssdk/dynamodb/kotlin/DeclarativeServiceTest.kt
@@ -86,28 +86,28 @@ class DeclarativeServiceTest {
             )
         )
         Assertions.assertEquals(
-            2, Flux.from(
-                s.query("1")
-            ).count().block().toInt()
+            2, Flux.from<DynamoDBEntity>(
+                s.query("1") as org.reactivestreams.Publisher<DynamoDBEntity>
+            ).count().block()!!.toInt()
         )
         Assertions.assertEquals(
-            1, Flux.from(
-                s.query("1", "1")
-            ).count().block().toInt()
+            1, Flux.from<DynamoDBEntity>(
+                s.query("1", "1") as org.reactivestreams.Publisher<DynamoDBEntity>
+            ).count().block()!!.toInt()
         )
         Assertions.assertEquals(
-            1, Flux.from(
-                s.queryByRangeIndex("1", "bar")
-            ).count().block().toInt()
+            1, Flux.from<DynamoDBEntity>(
+                s.queryByRangeIndex("1", "bar") as org.reactivestreams.Publisher<DynamoDBEntity>
+            ).count().block()!!.toInt()
         )
         Assertions.assertNull(
-            Flux.from(
-                s.queryByRangeIndex("1", "bar")
+            Flux.from<DynamoDBEntity>(
+                s.queryByRangeIndex("1", "bar") as org.reactivestreams.Publisher<DynamoDBEntity>
             ).blockFirst()!!.parentId
         )
         Assertions.assertEquals(
-            "bar", Flux.from(
-                s.queryByRangeIndex("1", "bar")
+            "bar", Flux.from<DynamoDBEntity>(
+                s.queryByRangeIndex("1", "bar") as org.reactivestreams.Publisher<DynamoDBEntity>
             ).blockFirst()?.rangeIndex
         )
         val byDates = s.queryByDates(
@@ -152,9 +152,9 @@ class DeclarativeServiceTest {
             )!!.size
         )
         Assertions.assertEquals(
-            2, Flux.from(
-                s.scanAllByRangeIndex("bar")
-            ).count().block().toInt()
+            2, Flux.from<DynamoDBEntity>(
+                s.scanAllByRangeIndex("bar") as org.reactivestreams.Publisher<DynamoDBEntity>
+            ).count().block()!!.toInt()
         )
         s.increment("1", "1")
         s.increment("1", "1")

--- a/settings.gradle
+++ b/settings.gradle
@@ -22,6 +22,7 @@ pluginManagement {
         mavenCentral()
     }
     plugins {
+        id 'com.agorapulse.gradle.root-project'                version "${agorapulseGradlePluginsVersion}"
         id 'com.agorapulse.gradle.micronaut-library'           version "${agorapulseGradlePluginsVersion}"
         id 'com.agorapulse.gradle.groovy-common-configuration' version "${agorapulseGradlePluginsVersion}"
         id 'com.agorapulse.gradle.guide'                       version "${agorapulseGradlePluginsVersion}"

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,68 +18,71 @@
 pluginManagement {
     repositories {
         gradlePluginPortal()
+        maven { url 'https://agorapulse.jfrog.io/agorapulse/gradle-plugins-releases-local/' }
+        mavenCentral()
     }
     plugins {
-        id 'org.kordamp.gradle.settings'            version kordampVersion
-        id 'org.kordamp.gradle.groovy-project'      version kordampVersion
-        id 'org.kordamp.gradle.checkstyle'          version kordampVersion
-        id 'org.kordamp.gradle.codenarc'            version kordampVersion
-        id 'org.kordamp.gradle.guide'               version kordampVersion
-        id 'org.kordamp.gradle.coveralls'           version kordampVersion
-        id 'org.ajoberstar.git-publish'             version gitPublishPluginVersion
+        id 'com.agorapulse.gradle.micronaut-library'           version "${agorapulseGradlePluginsVersion}"
+        id 'com.agorapulse.gradle.groovy-common-configuration' version "${agorapulseGradlePluginsVersion}"
+        id 'com.agorapulse.gradle.guide'                       version "${agorapulseGradlePluginsVersion}"
+        id 'com.vanniktech.maven.publish'                      version "${mavenCentralPublishPluginVersion}"
+        id 'org.jetbrains.kotlin.jvm'                          version "${kotlinVersion}"
+        id 'org.jetbrains.kotlin.plugin.allopen'               version "${kotlinVersion}"
+        id 'com.google.devtools.ksp'                           version "${kspVersion}"
     }
 }
 
 buildscript {
     repositories {
-        mavenCentral()
         gradlePluginPortal()
+        maven { url 'https://agorapulse.jfrog.io/agorapulse/gradle-plugins-releases-local/' }
+        mavenCentral()
     }
     dependencies {
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
-        classpath("org.jetbrains.kotlin.plugin.allopen:org.jetbrains.kotlin.plugin.allopen.gradle.plugin:$kotlinVersion")
-        classpath("com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin:$kspVersion")
-        classpath("io.micronaut.gradle:micronaut-minimal-plugin:$micronautGradlePluginVersion")
-        classpath("com.vanniktech:gradle-maven-publish-plugin:$mavenCentralPublishPluginVersion")
+        classpath "io.micronaut.gradle:micronaut-minimal-plugin:$micronautGradlePluginVersion"
+        classpath "com.agorapulse.gradle:micronaut-library:$agorapulseGradlePluginsVersion"
+        classpath "com.agorapulse.gradle:groovy-common-configuration:$agorapulseGradlePluginsVersion"
+        classpath "com.vanniktech:gradle-maven-publish-plugin:$mavenCentralPublishPluginVersion"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+        classpath "org.jetbrains.kotlin.plugin.allopen:org.jetbrains.kotlin.plugin.allopen.gradle.plugin:$kotlinVersion"
+        classpath "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin:$kspVersion"
     }
 }
-
 
 plugins {
-    id 'org.kordamp.gradle.settings'
-    id 'com.gradle.enterprise' version '3.15.1'
+    id 'com.agorapulse.gradle.settings' version "${agorapulseGradlePluginsVersion}"
+    id 'com.gradle.develocity'          version "${develocityPluginVersion}"
 }
 
-gradleEnterprise {
+develocity {
     buildScan {
-        publishAlways()
-        termsOfServiceUrl = "https://gradle.com/terms-of-service"
-        termsOfServiceAgree = "yes"
+        termsOfUseUrl = 'https://gradle.com/terms-of-service'
+        termsOfUseAgree = 'yes'
+        publishing.onlyIf { true }
     }
 }
 
-
-projects {
-    directories = ['subprojects', 'examples', 'docs', 'benchmarks', 'platforms', 'kotlin-libs']
+gradleProjects {
+    directories = ['subprojects', 'platforms', 'kotlin-libs', 'benchmarks', 'examples', 'docs']
 
     plugins {
-        dir('benchmarks') {
-            id 'io.micronaut.minimal.library'
+        dir('subprojects') {
+            id 'groovy'
+            id 'java-library'
+            id 'com.agorapulse.gradle.micronaut-library'
+            id 'com.agorapulse.gradle.groovy-common-configuration'
+            id 'com.vanniktech.maven.publish'
         }
         dir('platforms') {
             id 'java-platform'
             id 'com.vanniktech.maven.publish'
         }
-
-        dir('subprojects') {
-            id 'io.micronaut.minimal.library'
-            id 'groovy'
-            id 'java-library'
+        dir('kotlin-libs') {
+            id 'com.agorapulse.gradle.micronaut-library'
             id 'com.vanniktech.maven.publish'
         }
-
-        dir('kotlin-libs') {
-            id 'io.micronaut.minimal.library'
+        dir('benchmarks') {
+            id 'com.agorapulse.gradle.micronaut-library'
         }
     }
 }

--- a/subprojects/micronaut-amazon-awssdk-core/src/main/java/com/agorapulse/micronaut/amazon/awssdk/core/DefaultRegionAndEndpointConfiguration.java
+++ b/subprojects/micronaut-amazon-awssdk-core/src/main/java/com/agorapulse/micronaut/amazon/awssdk/core/DefaultRegionAndEndpointConfiguration.java
@@ -17,7 +17,7 @@
  */
 package com.agorapulse.micronaut.amazon.awssdk.core;
 
-import io.micronaut.core.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Default region and endpoint configuration.

--- a/subprojects/micronaut-amazon-awssdk-core/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/core/client/NettyClientCustomizer.java
+++ b/subprojects/micronaut-amazon-awssdk-core/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/core/client/NettyClientCustomizer.java
@@ -19,7 +19,7 @@ package com.agorapulse.micronaut.amazon.awssdk.core.client;
 
 import io.micronaut.context.event.BeanCreatedEvent;
 import io.micronaut.context.event.BeanCreatedEventListener;
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 import jakarta.inject.Singleton;
 import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
 

--- a/subprojects/micronaut-amazon-awssdk-dynamodb-annotation-processor/src/main/java/com/agorapulse/micronaut/amazon/awssdk/dynamodb/annotation/remap/DynamoDbBeanAnnotationRemapper.java
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb-annotation-processor/src/main/java/com/agorapulse/micronaut/amazon/awssdk/dynamodb/annotation/remap/DynamoDbBeanAnnotationRemapper.java
@@ -22,7 +22,7 @@ import io.micronaut.core.annotation.Introspected;
 import io.micronaut.inject.annotation.AnnotationRemapper;
 import io.micronaut.inject.visitor.VisitorContext;
 
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;

--- a/subprojects/micronaut-amazon-awssdk-dynamodb-annotation-processor/src/main/java/com/agorapulse/micronaut/amazon/awssdk/dynamodb/annotation/remap/ServiceAnnotationRemapper.java
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb-annotation-processor/src/main/java/com/agorapulse/micronaut/amazon/awssdk/dynamodb/annotation/remap/ServiceAnnotationRemapper.java
@@ -21,7 +21,7 @@ import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.inject.annotation.AnnotationRemapper;
 import io.micronaut.inject.visitor.VisitorContext;
 
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 import java.util.Collections;
 import java.util.List;
 

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/main/java/com/agorapulse/micronaut/amazon/awssdk/dynamodb/AsyncDynamoDbService.java
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/main/java/com/agorapulse/micronaut/amazon/awssdk/dynamodb/AsyncDynamoDbService.java
@@ -24,7 +24,7 @@ import com.agorapulse.micronaut.amazon.awssdk.dynamodb.builder.DetachedUpdate;
 import com.agorapulse.micronaut.amazon.awssdk.dynamodb.builder.QueryBuilder;
 import com.agorapulse.micronaut.amazon.awssdk.dynamodb.builder.ScanBuilder;
 import com.agorapulse.micronaut.amazon.awssdk.dynamodb.builder.UpdateBuilder;
-import io.micronaut.core.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import org.reactivestreams.Publisher;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbAsyncTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/main/java/com/agorapulse/micronaut/amazon/awssdk/dynamodb/DefaultAsyncDynamoDbService.java
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/main/java/com/agorapulse/micronaut/amazon/awssdk/dynamodb/DefaultAsyncDynamoDbService.java
@@ -28,7 +28,7 @@ import com.agorapulse.micronaut.amazon.awssdk.dynamodb.events.DynamoDbEvent;
 import com.agorapulse.micronaut.amazon.awssdk.dynamodb.exception.FailedBatchRequestException;
 import io.micronaut.context.event.ApplicationEventPublisher;
 import io.micronaut.core.annotation.AnnotationValue;
-import io.micronaut.core.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import io.micronaut.core.beans.BeanIntrospection;
 import io.micronaut.core.beans.BeanProperty;
 import org.reactivestreams.Publisher;

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/main/java/com/agorapulse/micronaut/amazon/awssdk/dynamodb/DefaultDynamoDbService.java
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/main/java/com/agorapulse/micronaut/amazon/awssdk/dynamodb/DefaultDynamoDbService.java
@@ -48,7 +48,7 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.Projection;
 import software.amazon.awssdk.services.dynamodb.model.ProjectionType;
 
-import io.micronaut.core.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/main/java/com/agorapulse/micronaut/amazon/awssdk/dynamodb/DynamoDbService.java
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/main/java/com/agorapulse/micronaut/amazon/awssdk/dynamodb/DynamoDbService.java
@@ -28,7 +28,7 @@ import org.reactivestreams.Publisher;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 
-import io.micronaut.core.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 import java.util.function.Consumer;
 import java.util.function.Function;
 

--- a/subprojects/micronaut-amazon-awssdk-gcp/micronaut-amazon-awssdk-gcp.gradle
+++ b/subprojects/micronaut-amazon-awssdk-gcp/micronaut-amazon-awssdk-gcp.gradle
@@ -21,5 +21,5 @@ dependencies {
     // GCP Auth library for Workload Identity Federation
     api "com.google.auth:google-auth-library-oauth2-http:$googleAuthVersion"
     
-    testImplementation 'org.testcontainers:localstack'
+    testImplementation "org.testcontainers:localstack:$testcontainersVersion"
 }

--- a/subprojects/micronaut-amazon-awssdk-kinesis-annotation-processor/src/main/java/com/agorapulse/micronaut/amazon/awssdk/kinesis/annotation/remap/KinesisClientRemapper.java
+++ b/subprojects/micronaut-amazon-awssdk-kinesis-annotation-processor/src/main/java/com/agorapulse/micronaut/amazon/awssdk/kinesis/annotation/remap/KinesisClientRemapper.java
@@ -21,7 +21,7 @@ import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.inject.annotation.AnnotationRemapper;
 import io.micronaut.inject.visitor.VisitorContext;
 
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 import java.util.Collections;
 import java.util.List;
 

--- a/subprojects/micronaut-amazon-awssdk-kinesis-worker/micronaut-amazon-awssdk-kinesis-worker.gradle
+++ b/subprojects/micronaut-amazon-awssdk-kinesis-worker/micronaut-amazon-awssdk-kinesis-worker.gradle
@@ -21,6 +21,7 @@ dependencies {
     }
 
    api project(':micronaut-amazon-awssdk-core')
+    api 'jakarta.validation:jakarta.validation-api'
     implementation project(':micronaut-amazon-awssdk-cloudwatch')
     implementation project(':micronaut-amazon-awssdk-dynamodb')
     implementation project(':micronaut-amazon-awssdk-kinesis')

--- a/subprojects/micronaut-amazon-awssdk-kinesis-worker/src/main/groovy/com/agorapulse/micronaut/amazon/awssdk/kinesis/worker/KinesisClientConfiguration.java
+++ b/subprojects/micronaut-amazon-awssdk-kinesis-worker/src/main/groovy/com/agorapulse/micronaut/amazon/awssdk/kinesis/worker/KinesisClientConfiguration.java
@@ -24,9 +24,9 @@ import software.amazon.awssdk.services.kinesis.KinesisAsyncClient;
 import software.amazon.kinesis.common.ConfigsBuilder;
 import software.amazon.kinesis.processor.ShardRecordProcessorFactory;
 
-import io.micronaut.core.annotation.NonNull;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotEmpty;
+import org.jspecify.annotations.NonNull;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
 import java.net.URI;
 import java.util.Optional;
 

--- a/subprojects/micronaut-amazon-awssdk-kinesis-worker/src/main/groovy/com/agorapulse/micronaut/amazon/awssdk/kinesis/worker/KinesisListenerMethodProcessor.java
+++ b/subprojects/micronaut-amazon-awssdk-kinesis-worker/src/main/groovy/com/agorapulse/micronaut/amazon/awssdk/kinesis/worker/KinesisListenerMethodProcessor.java
@@ -178,7 +178,7 @@ public class KinesisListenerMethodProcessor implements ExecutableMethodProcessor
     }
 
     @Override
-    public void process(BeanDefinition<?> beanDefinition, ExecutableMethod<?, ?> method) {
+    public <B> void process(BeanDefinition<B> beanDefinition, ExecutableMethod<B, ?> method) {
         Argument[] arguments = method.getArguments();
 
         if (arguments.length > 2) {

--- a/subprojects/micronaut-amazon-awssdk-kinesis-worker/src/main/groovy/com/agorapulse/micronaut/amazon/awssdk/kinesis/worker/ProcessRecordsEvent.java
+++ b/subprojects/micronaut-amazon-awssdk-kinesis-worker/src/main/groovy/com/agorapulse/micronaut/amazon/awssdk/kinesis/worker/ProcessRecordsEvent.java
@@ -17,8 +17,8 @@
  */
 package com.agorapulse.micronaut.amazon.awssdk.kinesis.worker;
 
-import io.micronaut.core.annotation.NonNull;
-import io.micronaut.core.annotation.Nullable;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Event published after processing a batch of Kinesis records.

--- a/subprojects/micronaut-amazon-awssdk-lambda-annotation-processor/src/main/java/com/agorapulse/micronaut/amazon/awssdk/lambda/annotation/remap/LambdaClientRemapper.java
+++ b/subprojects/micronaut-amazon-awssdk-lambda-annotation-processor/src/main/java/com/agorapulse/micronaut/amazon/awssdk/lambda/annotation/remap/LambdaClientRemapper.java
@@ -21,7 +21,7 @@ import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.inject.annotation.AnnotationRemapper;
 import io.micronaut.inject.visitor.VisitorContext;
 
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 import java.util.Collections;
 import java.util.List;
 

--- a/subprojects/micronaut-amazon-awssdk-s3/src/main/java/com/agorapulse/micronaut/amazon/awssdk/s3/DefaultSimpleStorageService.java
+++ b/subprojects/micronaut-amazon-awssdk-s3/src/main/java/com/agorapulse/micronaut/amazon/awssdk/s3/DefaultSimpleStorageService.java
@@ -35,6 +35,7 @@ import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequ
 import software.amazon.awssdk.utils.IoUtils;
 import software.amazon.awssdk.utils.Md5Utils;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -192,7 +193,7 @@ public class DefaultSimpleStorageService implements SimpleStorageService {
     @Override
     public String storeMultipartFile(String bucketName, String path, PartData partData, Consumer<PutObjectRequest.Builder> additionalConfig) throws IOException {
         byte[] bytes = partData.getBytes();
-        return storeInputStream(bucketName, path, partData.getInputStream(), b -> {
+        return storeInputStream(bucketName, path, new ByteArrayInputStream(bytes), b -> {
             b.contentLength(Integer.valueOf(bytes.length).longValue());
             b.contentMD5(Md5Utils.md5AsBase64(bytes));
             partData.getContentType().ifPresent(t -> b.contentType(t.getName()));

--- a/subprojects/micronaut-amazon-awssdk-s3/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/s3/MockPartData.groovy
+++ b/subprojects/micronaut-amazon-awssdk-s3/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/s3/MockPartData.groovy
@@ -18,38 +18,19 @@
 package com.agorapulse.micronaut.amazon.awssdk.s3
 
 import groovy.transform.CompileStatic
+import io.micronaut.core.io.buffer.ReadBufferFactory
 import io.micronaut.http.MediaType
+import io.micronaut.http.multipart.FormFieldMetadata
 import io.micronaut.http.multipart.PartData
 
-import java.nio.ByteBuffer
-
 @CompileStatic
-class MockPartData implements PartData {
+class MockPartData {
 
-    private final String text
-
-    MockPartData(String text) {
-        this.text = text
-    }
-
-    @Override
-    InputStream getInputStream() throws IOException {
-        return new ByteArrayInputStream(text.bytes)
-    }
-
-    @Override
-    byte[] getBytes() throws IOException {
-        return text.bytes
-    }
-
-    @Override
-    ByteBuffer getByteBuffer() throws IOException {
-        throw new UnsupportedOperationException('Not implemented')
-    }
-
-    @Override
-    Optional<MediaType> getContentType() {
-        return Optional.of(MediaType.TEXT_PLAIN_TYPE)
+    static PartData of(String text) {
+        return new PartData(
+            new FormFieldMetadata(null, null, MediaType.TEXT_PLAIN_TYPE),
+            ReadBufferFactory.getJdkFactory().adapt(text.bytes)
+        )
     }
 
 }

--- a/subprojects/micronaut-amazon-awssdk-s3/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/s3/SimpleStorageServiceSpec.groovy
+++ b/subprojects/micronaut-amazon-awssdk-s3/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/s3/SimpleStorageServiceSpec.groovy
@@ -125,7 +125,7 @@ class SimpleStorageServiceSpec extends Specification {
 
     void 'upload multipart'() {
         when:
-            service.storeMultipartFile('mix/multi', new MockPartData('Hello')) {
+            service.storeMultipartFile('mix/multi', MockPartData.of('Hello')) {
                 acl ObjectCannedACL.PUBLIC_READ
             }
             S3Object object = blocking(service.listObjectSummaries('mix'))
@@ -136,7 +136,7 @@ class SimpleStorageServiceSpec extends Specification {
 
     void 'upload multipart - other'() {
         when:
-            service.storeMultipartFile(OTHER_BUCKET, 'mix/multi', new MockPartData('Hello')) {
+            service.storeMultipartFile(OTHER_BUCKET, 'mix/multi', MockPartData.of('Hello')) {
                 acl ObjectCannedACL.PUBLIC_READ
             }
             S3Object object = blocking(service.listObjectSummaries(OTHER_BUCKET, 'mix'))
@@ -150,7 +150,7 @@ class SimpleStorageServiceSpec extends Specification {
         when:
             String newKey = 'mix/moved-' + desiredAcl
             String oldKey = 'mix/to-be-moved-' + desiredAcl
-            service.storeMultipartFile(oldKey, new MockPartData('Public')) {
+            service.storeMultipartFile(oldKey, MockPartData.of('Public')) {
                 acl desiredAcl
                 tagging(Tagging.builder().tagSet(Tag.builder().key('foo').value('bar').build()).build())
                 contentDisposition 'attachment'
@@ -277,7 +277,7 @@ class SimpleStorageServiceSpec extends Specification {
         expect:
             !service.exists(MY_BUCKET, KEY)
             !service.storeInputStream(KEY, new ByteArrayInputStream('Hello'.bytes))
-            !service.storeMultipartFile(KEY, new MockPartData('Foo'))
+            !service.storeMultipartFile(KEY, MockPartData.of('Foo'))
     }
 
     private static <T> T blocking(Publisher<T> publisher) {

--- a/subprojects/micronaut-amazon-awssdk-s3/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/s3/SimpleStorageServiceTest.java
+++ b/subprojects/micronaut-amazon-awssdk-s3/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/s3/SimpleStorageServiceTest.java
@@ -42,7 +42,7 @@ import static org.junit.jupiter.api.Assertions.*;
 @Property(name = "aws.s3.bucket", value = SimpleStorageServiceTest.MY_BUCKET)           // <2>
 public class SimpleStorageServiceTest {
     // end::header[]
-    public static final String MY_BUCKET = "testbucket";
+    public static final String MY_BUCKET = "java-testbucket";
 
     private static final String KEY = "foo/bar.baz";
     private static final String SAMPLE_CONTENT = "hello world!";

--- a/subprojects/micronaut-amazon-awssdk-ses/micronaut-amazon-awssdk-ses.gradle
+++ b/subprojects/micronaut-amazon-awssdk-ses/micronaut-amazon-awssdk-ses.gradle
@@ -20,7 +20,7 @@ dependencies {
 
    api project(':micronaut-amazon-awssdk-core')
     implementation "space.jasan:groovy-closure-support:$closureSupportVersion"
-    implementation 'javax.mail:mail:1.4.4'
+    implementation 'org.eclipse.angus:jakarta.mail:2.0.3'
 
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation project(':micronaut-amazon-awssdk-integration-testing')

--- a/subprojects/micronaut-amazon-awssdk-ses/src/main/java/com/agorapulse/micronaut/amazon/awssdk/ses/DefaultSimpleEmailService.java
+++ b/subprojects/micronaut-amazon-awssdk-ses/src/main/java/com/agorapulse/micronaut/amazon/awssdk/ses/DefaultSimpleEmailService.java
@@ -27,16 +27,16 @@ import software.amazon.awssdk.services.ses.model.MessageTag;
 import software.amazon.awssdk.services.ses.model.SendEmailRequest;
 import software.amazon.awssdk.services.ses.model.SendRawEmailRequest;
 
-import javax.activation.DataHandler;
-import javax.activation.DataSource;
-import javax.mail.BodyPart;
-import javax.mail.MessagingException;
-import javax.mail.Session;
-import javax.mail.internet.InternetAddress;
-import javax.mail.internet.MimeBodyPart;
-import javax.mail.internet.MimeMessage;
-import javax.mail.internet.MimeMultipart;
-import javax.mail.util.ByteArrayDataSource;
+import jakarta.activation.DataHandler;
+import jakarta.activation.DataSource;
+import jakarta.mail.BodyPart;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeBodyPart;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeMultipart;
+import jakarta.mail.util.ByteArrayDataSource;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -48,7 +48,7 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.stream.Collectors;
 
-import static javax.mail.Message.RecipientType.TO;
+import static jakarta.mail.Message.RecipientType.TO;
 
 /**
  * Default implementation of simple email service.

--- a/subprojects/micronaut-amazon-awssdk-ses/src/main/java/com/agorapulse/micronaut/amazon/awssdk/ses/MimeType.java
+++ b/subprojects/micronaut-amazon-awssdk-ses/src/main/java/com/agorapulse/micronaut/amazon/awssdk/ses/MimeType.java
@@ -17,7 +17,7 @@
  */
 package com.agorapulse.micronaut.amazon.awssdk.ses;
 
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;

--- a/subprojects/micronaut-amazon-awssdk-sns-annotation-processor/src/main/java/com/agorapulse/micronaut/amazon/awssdk/sns/annotation/remap/NotificationClientRemapper.java
+++ b/subprojects/micronaut-amazon-awssdk-sns-annotation-processor/src/main/java/com/agorapulse/micronaut/amazon/awssdk/sns/annotation/remap/NotificationClientRemapper.java
@@ -21,7 +21,7 @@ import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.inject.annotation.AnnotationRemapper;
 import io.micronaut.inject.visitor.VisitorContext;
 
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 import java.util.Collections;
 import java.util.List;
 

--- a/subprojects/micronaut-amazon-awssdk-sqs-annotation-processor/src/main/java/com/agorapulse/micronaut/amazon/awssdk/sqs/annotation/remap/QueueClientRemapper.java
+++ b/subprojects/micronaut-amazon-awssdk-sqs-annotation-processor/src/main/java/com/agorapulse/micronaut/amazon/awssdk/sqs/annotation/remap/QueueClientRemapper.java
@@ -21,7 +21,7 @@ import io.micronaut.core.annotation.AnnotationValue;
 import io.micronaut.inject.annotation.AnnotationRemapper;
 import io.micronaut.inject.visitor.VisitorContext;
 
-import io.micronaut.core.annotation.NonNull;
+import org.jspecify.annotations.NonNull;
 import java.util.Collections;
 import java.util.List;
 

--- a/subprojects/micronaut-amazon-awssdk-sqs/src/main/java/com/agorapulse/micronaut/amazon/awssdk/sqs/SimpleQueueServiceConfiguration.java
+++ b/subprojects/micronaut-amazon-awssdk-sqs/src/main/java/com/agorapulse/micronaut/amazon/awssdk/sqs/SimpleQueueServiceConfiguration.java
@@ -19,7 +19,7 @@ package com.agorapulse.micronaut.amazon.awssdk.sqs;
 
 import com.agorapulse.micronaut.amazon.awssdk.core.RegionAndEndpointConfiguration;
 
-import io.micronaut.core.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Default configuration for Simple Queue Service.


### PR DESCRIPTION
## Micronaut 5.x upgrade

Brings `micronaut-aws-sdk` to the Micronaut Framework 5.0 baseline (Java 25, Gradle 9.5, Groovy 5, Spock 2.4-groovy-5.0).

## What changed

### Build
- Bumped `micronautVersion` and the Micronaut Gradle plugin to `5.0.0`.
- Gradle wrapper bumped to `9.5.0`; Java toolchain pinned to 25 via `javaVersion=25` on every JVM subproject.
- Replaced the Kordamp Gradle plugins (`org.kordamp.gradle.*` — unmaintained since 0.54.0 in 2022 and incompatible with Gradle 9.5) with `com.agorapulse.gradle.*` convention plugins (`settings`, `micronaut-library`, `groovy-common-configuration`, `guide`).
- Switched build-scan publishing to the public Develocity (`com.gradle.develocity` → `gradle.com`).
- Dropped per-library aggregate-test/jacoco-report tasks and the Coveralls integration — the Develocity scan now aggregates everything.
- Enabled the local Gradle build cache.
- Centralised the `mavenPublishing { … }` + `signing { … }` block in the root build for the three publishable trees (`subprojects/`, `platforms/`, `kotlin-libs/`), matching the worker layout.

### Library version bumps (required by the M5 / Groovy 5 / Java 25 baseline)
- Groovy 5.0.0, Spock 2.4-groovy-5.0
- JUnit Jupiter 6.0.3
- Mockito 5.23.0
- Kotlin 2.3.21, KSP 2.3.7
- Jackson dataformat-cbor 3.0.0 (Jackson 3, matching M5's Jackson)
- Testcontainers 1.21.4 — the 1.17.x line still hard-required the AWS SDK v1 inside `LocalstackContainerHolder`; v2-only classpaths now boot LocalStack cleanly.

### Source-level M5 API fixes
- Nullability annotations swept from `io.micronaut.core.annotation.{Nullable,NonNull}` to `org.jspecify.annotations.{Nullable,NonNull}` across core / dynamodb / dynamodb-annotation-processor / kinesis-annotation-processor / kinesis-worker / lambda-annotation-processor / ses / sns-annotation-processor / sqs / sqs-annotation-processor. M5 standardised on JSpecify.
- `javax.{mail,activation,validation}` → `jakarta.{mail,activation,validation}` in SES (`DefaultSimpleEmailService`, `MimeType`) and kinesis-worker (`KinesisClientConfiguration`). The SES module's `javax.mail:mail:1.4.4` runtime is swapped for `org.eclipse.angus:jakarta.mail:2.0.3` (Angus is the new Jakarta Mail RI under EE9+).
- `KinesisListenerMethodProcessor.process(...)`: M5's `ExecutableMethodProcessor` declares the method as generic, so the unbounded override no longer satisfies the contract. Switched to `<B> void process(BeanDefinition<B>, ExecutableMethod<B, ?>)`.
- s3 `MockPartData` (test): `io.micronaut.http.multipart.PartData` is no longer an interface in M5 — it's a final record-like class. Replaced the mock with a `MockPartData.of(String)` factory that builds a real `PartData` from a `byte[]` via `FormFieldMetadata` + `ReadBufferFactory`.
- s3 `DefaultSimpleStorageService.storeMultipartFile`: the M5 `PartData` wraps a single-use `ReadBuffer` that closes itself after the first read. Reading the bytes once and wrapping them in a `ByteArrayInputStream` keeps the upload path working.
- kotlin-libs `DeclarativeServiceTest`: Java-side `Publisher` returns arrive in Kotlin as `Publisher<T?>?` platform types; the newer Reactor `Flux.from<T : Any>()` rejects them. Cast the calls to a non-null `Publisher<DynamoDBEntity>` and non-null-assert `.count().block()` results.

### Publishing
- Already on `com.vanniktech.maven.publish` 0.34.0 publishing through the new Central Portal (introduced before this PR). This PR drops the last legacy bit — the `-Dorg.ajoberstar.grgit.auth.username=…` system property — since `publishAndReleaseToMavenCentral` no longer needs it.

### Release workflow
- Modernised actions: `actions/setup-java@v4` (Java 25, Zulu) and `gradle/actions/setup-gradle@v5` instead of `@v4`.
- Added a `Configure git identity for gitPublishCommit` step before Release. `gradle-git-publish` 5.x no longer reads `GRGIT_USER` / `GRGIT_PASS` env vars or the `-Dorg.ajoberstar.grgit.auth.*` system properties; HTTPS push credentials are now wired to the `gitPublish { username; password }` extension in `docs/guide/guide.gradle` from `GIT_PUBLISH_USERNAME` / `GIT_PUBLISH_PASSWORD` env vars.
- The downstream `ping` job is now gated on `!github.event.release.prerelease` so RC / SNAPSHOT releases don't notify consumers.
- Marks the artifact as Micronaut 5–compatible in the downstream notification payload (`micronautCompatibility: [5]`).

### Required repository secrets
No new secrets. The existing `MAVEN_CENTRAL_USERNAME` / `MAVEN_CENTRAL_PASSWORD` / `SIGNING_*` / `AGORAPULSE_BOT_PERSONAL_TOKEN` set is reused — the bot token is now also exported as `GIT_PUBLISH_PASSWORD` for the guide push.

## Test plan
- [ ] CI `Check` workflow is green on Java 25
- [ ] Publishing a pre-release tag does not trigger the downstream `ping` job
- [ ] Publishing a stable tag pings `agorapulse-bom` and `agorapulse-oss` with `micronautCompatibility: [5]`
- [ ] The guide is pushed to the `gh-pages` branch with the `agorapulse-bot` identity