### PR TITLE
fix(guide): drop redundant asciidoctorExtensions wiring to unblock release

### DIFF
--- a/docs/guide/guide.gradle
+++ b/docs/guide/guide.gradle
@@ -27,16 +27,7 @@ gitPublish {
     password = providers.environmentVariable('GIT_PUBLISH_PASSWORD').orElse('')
 }
 
-configurations {
-    asciidoctorExtensions
-}
-
-dependencies {
-    asciidoctorExtensions 'com.bmuschko:asciidoctorj-tabbed-code-extension:0.3'
-}
-
 asciidoctor {
-    configurations 'asciidoctorExtensions'
     baseDirFollowsSourceDir()
 
     attributes = [


### PR DESCRIPTION
## Summary

The 5.0.0.RC1 Release workflow [failed silently](https://github.com/agorapulse/micronaut-aws-sdk/actions) on `:guide:asciidoctor` with

```
ClassCastException: UnionFileCollection cannot be cast to Configuration
Could not determine the dependencies of task ':guide:asciidoctor'.
```

The tag was created, the Check workflow stayed green (it doesn't run `:guide:asciidoctor`), but the artifact never made it to Maven Central — `micronaut-aws-sdk-core-5.0.0.RC1.jar` returns **HTTP 404** today.

## Fix

Drop the local `asciidoctorExtensions` configuration + `com.bmuschko:asciidoctorj-tabbed-code-extension:0.3` dep. The Agorapulse `com.agorapulse.gradle.guide` plugin already pulls that extension transitively, and asciidoctorj's SPI auto-registers it. The local wiring was a redundant double-registration — exactly what trips the Gradle 9.5 cast.

## No visual regression

Tabs still work because the transitive extension is still on the asciidoctor classpath. Verified locally:
* `./gradlew :guide:asciidoctor` succeeds
* generated `index.html` still contains the tab JS (`addBlockSwitches`, `switch--item`) and styles
* `<div class="listingblock primary">` / `secondary` survive as before

Same approach gru 3.0.0.RC2 already shipped successfully (https://agorapulse.github.io/gru/ has live tabbed Java/Kotlin/Groovy blocks), and the same fix is queued for micronaut-console (#41).

## After merge

The 5.0.0.RC1 tag will need to be deleted + re-cut so the Release workflow can actually publish to Maven Central.

## Test plan
- [x] `./gradlew :guide:asciidoctor` succeeds locally
- [x] generated HTML still contains tab JS/CSS
- [ ] CI green on this PR
- [ ] Delete + retag 5.0.0.RC1 once merged
