### PR TITLE
fix(deps): drop stale jackson-dataformat-cbor constraint

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -49,10 +49,6 @@ spockVersion=2.4-groovy-5.0
 # other versions creates conflicts in Groovydoc
 groovyVersion = 5.0.0
 
-# this should be aligned to Micronaut version
-# required for AWS CBOR marshalling
-jackson.datatype.version=3.0.0
-
 # kinesis client version
 kinesisClientV2Version=2.7.2
 

--- a/platforms/micronaut-aws-sdk-dependencies/micronaut-aws-sdk-dependencies.gradle
+++ b/platforms/micronaut-aws-sdk-dependencies/micronaut-aws-sdk-dependencies.gradle
@@ -44,7 +44,6 @@ dependencies {
         api "software.amazon.awssdk:apache-client:$project.awsSdk2Version"
 
         api group: 'com.amazonaws', name: 'aws-lambda-java-events', version: awsLambdaEventsVersion
-        api group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: project['jackson.datatype.version']
 
         // GCP dependencies for Workload Identity Federation
         api "com.google.auth:google-auth-library-oauth2-http:$googleAuthVersion"


### PR DESCRIPTION
## Problem

The `micronaut-aws-sdk-dependencies` BOM pinned `com.fasterxml.jackson.dataformat:jackson-dataformat-cbor`, and the Micronaut 5 upgrade bumped that pin to **`3.0.0`** — a version that **does not exist on Maven Central**. Jackson 3 moved to the new `tools.jackson:*` coordinates, so under the legacy `com.fasterxml.jackson.dataformat:*` group the latest release is in the 2.x line.

Downstream resolution failed with:

```
Could not find com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:3.0.0.
Required by:
    com.agorapulse:micronaut-amazon-awssdk-kinesis:5.0.0.RC2
        > com.agorapulse:micronaut-aws-sdk-dependencies:5.0.0.RC2
```

This blocks the Micronaut 5 upgrade in `agorapulse/platform` (PR #75744).

## Fix: drop the constraint entirely

The library no longer needs this artifact at all. Since AWS SDK v2 **2.17**, the SDK marshals CBOR using its own *shaded* copy (`software.amazon.awssdk:third-party-jackson-dataformat-cbor`, pulled via `aws-cbor-protocol`). The unshaded `com.fasterxml.jackson.dataformat:jackson-dataformat-cbor` is **not on the classpath of any module here** — confirmed via `dependencyInsight` on both `micronaut-amazon-awssdk-kinesis` and `micronaut-amazon-awssdk-kinesis-worker` (KCL 2.x): *"No dependencies matching given input were found."*

The BOM `constraint` never *added* CBOR to anything — it only imposed a version on downstream consumers that pull the artifact from elsewhere, which is exactly what broke the platform. Removing it lets those consumers resolve CBOR via their own BOMs (the platform already gets a valid version via `micronaut-micrometer-bom`). The accompanying "required for AWS CBOR marshalling" comment was stale since 2.17.

Two lines removed:

```diff
# gradle.properties
-# this should be aligned to Micronaut version
-# required for AWS CBOR marshalling
-jackson.datatype.version=3.0.0

# platforms/micronaut-aws-sdk-dependencies/micronaut-aws-sdk-dependencies.gradle
-        api group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-cbor', version: project['jackson.datatype.version']
```

## Verification (local, JDK 25)

- `:micronaut-amazon-awssdk-kinesis:dependencies --configuration runtimeClasspath` → **BUILD SUCCESSFUL**; only AWS SDK's shaded `third-party-jackson-dataformat-cbor:2.44.7` present, no unshaded CBOR, no `3.0.0`.
- Regenerated `micronaut-aws-sdk-dependencies` BOM POM contains **zero** `jackson-dataformat-cbor` references (was pinned to the bogus `3.0.0`).
- Patch independently verified working locally.

## Follow-up (handled outside this PR)

After merge, cut a `5.0.0.RC3` GitHub Release to trigger the Maven Central publish, then bump `micronautAwsSdkVersion` in the platform PR (#75744) `versions.properties` overrides.

https://claude.ai/code/session_01Ra3PVhLrJZ9rEuizbkmMMR