### PR TITLE
chore(deps): bump Micronaut to 5.0.6 and gru to 3.0.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -28,10 +28,10 @@ mavenCentralPublishPluginVersion = 0.34.0
 develocityPluginVersion = 4.2.2
 gitPublishPluginVersion = 2.1.3
 
-micronautVersion = 5.0.0
-micronautGradlePluginVersion = 5.0.0
+micronautVersion = 5.0.6
+micronautGradlePluginVersion = 5.0.2
 
-gruVersion = 2.2.0
+gruVersion = 3.0.0
 awsSdk2Version = 2.41.16
 awsLambdaRuntimeVersion=2.5.0
 awsLambdaEventsVersion=3.16.1

--- a/subprojects/micronaut-amazon-awssdk-kinesis/micronaut-amazon-awssdk-kinesis.gradle
+++ b/subprojects/micronaut-amazon-awssdk-kinesis/micronaut-amazon-awssdk-kinesis.gradle
@@ -24,7 +24,6 @@ dependencies {
 
    api project(':micronaut-amazon-awssdk-core')
     implementation "space.jasan:groovy-closure-support:$closureSupportVersion"
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     implementation "io.projectreactor:reactor-core:$projectReactorVersion"
 
     testImplementation project(':micronaut-amazon-awssdk-integration-testing')


### PR DESCRIPTION
Bumps Micronaut to 5.0.6, the Micronaut Gradle plugin to 5.0.2, and gru to the 3.0.0 GA. Part of the MN 5.0.6 OSS release train (ships as micronaut-aws-sdk 5.0.0 GA).