### PR TITLE
chore(deps): bump Micronaut to 5.1.0 and fix guide title attributes

### DIFF
--- a/docs/guide/guide.gradle
+++ b/docs/guide/guide.gradle
@@ -35,6 +35,9 @@ asciidoctor {
         'aws-sdk-version': awsSdk2Version,
         'source-highlighter': 'prettify',
         'root-dir': rootDir,
-        'project-slug': slug
+        'project-slug': slug,
+        'project-title': 'Micronaut AWS SDK',
+        'project-version': project.version,
+        'project-author': 'Agorapulse'
     ]
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,7 +28,7 @@ mavenCentralPublishPluginVersion = 0.34.0
 develocityPluginVersion = 4.2.2
 gitPublishPluginVersion = 2.1.3
 
-micronautVersion = 5.0.6
+micronautVersion = 5.1.0
 micronautGradlePluginVersion = 5.0.2
 
 gruVersion = 3.0.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,7 +31,7 @@ gitPublishPluginVersion = 2.1.3
 micronautVersion = 5.1.0
 micronautGradlePluginVersion = 5.0.2
 
-gruVersion = 3.0.0
+gruVersion = 3.0.2
 awsSdk2Version = 2.41.16
 awsLambdaRuntimeVersion=2.5.0
 awsLambdaEventsVersion=3.16.1

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/micronaut-amazon-awssdk-dynamodb.gradle
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/micronaut-amazon-awssdk-dynamodb.gradle
@@ -38,6 +38,14 @@ dependencies {
     testImplementation "software.amazon.awssdk:apache-client:$project.awsSdk2Version"
 }
 
+configurations.named('testRuntimeClasspath') {
+    // Micronaut AWS 5.1.0 pulls the AWS SDK v2 BOM (2.48.3), which newly adds
+    // apache5-client. Its SdkHttpClient.Builder bean collides with aws-crt-client's
+    // under the same map key, breaking map-of-beans injection; exclude it so the
+    // explicitly tested http clients inject cleanly.
+    exclude group: 'software.amazon.awssdk', module: 'apache5-client'
+}
+
 if (project.findProperty('test.aws.dynamodb.v2') == 'async') {
     tasks.withType(Test).configureEach {
         systemProperty 'aws.dynamodb.async', 'true'


### PR DESCRIPTION
Bumps Micronaut 5.0.6 -> 5.1.0 (Gradle plugin stays 5.0.2). MN 5.1.0's AWS SDK BOM (2.48.3) newly pulls `apache5-client`, whose `SdkHttpClient.Builder` bean collides with `aws-crt-client` under the map key `builder` (breaking map-of-beans injection in the dynamodb tests) — excluded it from the dynamodb test runtime classpath. Also fixes the published guide rendering literal {project-title}/{project-version} by adding the project-title/version/author asciidoctor attributes. Ships as micronaut-aws-sdk 5.0.1.