### PR TITLE
Support annotation-driven scans for declarative services

### DIFF
--- a/docs/guide/src/docs/asciidoc/dynamodb.adoc
+++ b/docs/guide/src/docs/asciidoc/dynamodb.adoc
@@ -725,6 +725,17 @@ include::{root-dir}/kotlin-libs/micronaut-amazon-awssdk-dynamodb-kotlin/src/test
 <4> `@Scan` annotation accepts a class which implements `Function<Map<String, Object>, DetachedScan>`
 <5> The arguments have no special meaning but you can use them in the scan definition. The method must return either `Publisher`, `Stream` or `List` of entities.
 
+A method that has no partition key argument is served by a scan instead of a query, so the advanced finder methods described above can also be used to scan the whole table. Every remaining argument must be an explicit `@Filter` (a bare, unannotated argument is treated as a forgotten `@PartitionKey` and rejected), and `@Limit`, `@Page` and `@LastEvaluatedKey` page through the scan the same way they page through a query.
+
+[source,java,indent=0,options="nowrap"]
+----
+List<DynamoDBEntity> scanAllByNumberGreaterThan(
+    @Filter(value = Filter.Operator.GT, name = "number") int number,
+    @LastEvaluatedKey DynamoDBEntity lastEvaluatedKey,
+    @Limit int limit
+);
+----
+
 =====  Updates
 Declarative services allows you to execute fine-grained updates. Any method annotated with `@Update` will perform the update in the DynamoDB table.
 

--- a/docs/guide/src/docs/asciidoc/dynamodb.adoc
+++ b/docs/guide/src/docs/asciidoc/dynamodb.adoc
@@ -725,7 +725,7 @@ include::{root-dir}/kotlin-libs/micronaut-amazon-awssdk-dynamodb-kotlin/src/test
 <4> `@Scan` annotation accepts a class which implements `Function<Map<String, Object>, DetachedScan>`
 <5> The arguments have no special meaning but you can use them in the scan definition. The method must return either `Publisher`, `Stream` or `List` of entities.
 
-A method that has no partition key argument is served by a scan instead of a query, so the advanced finder methods described above can also be used to scan the whole table. Every remaining argument must be an explicit `@Filter` (a bare, unannotated argument is treated as a forgotten `@PartitionKey` and rejected), and `@Limit`, `@Page` and `@LastEvaluatedKey` page through the scan the same way they page through a query.
+A method that has no partition key argument is served by a scan instead of a query, so the advanced finder methods described above can also be used to scan the whole table. To avoid an accidental, expensive full-table scan the intent must be explicit: the method name starts with `scan`, or the method carries a scan annotation (`@Filter`, `@Limit`, `@Page`, `@LastEvaluatedKey`, `@Index` or `@Consistent`). A partition-less finder with neither is rejected. Every remaining argument must be an explicit `@Filter` (a bare, unannotated argument is treated as a forgotten `@PartitionKey` and rejected), and `@Limit`, `@Page` and `@LastEvaluatedKey` page through the scan the same way they page through a query.
 
 [source,java,indent=0,options="nowrap"]
 ----

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/main/java/com/agorapulse/micronaut/amazon/awssdk/dynamodb/AsyncDynamoDbServiceIntroduction.java
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/main/java/com/agorapulse/micronaut/amazon/awssdk/dynamodb/AsyncDynamoDbServiceIntroduction.java
@@ -197,20 +197,30 @@ public class AsyncDynamoDbServiceIntroduction implements DynamoDbServiceIntroduc
             }
         }
 
-        if (methodName.startsWith("query") || methodName.startsWith("findAll") || methodName.startsWith("list") || methodName.startsWith("count") || methodName.startsWith("delete")) {
+        if (methodName.startsWith("query") || methodName.startsWith("scan") || methodName.startsWith("findAll") || methodName.startsWith("list") || methodName.startsWith("count") || methodName.startsWith("delete")) {
             QueryArguments partitionAndSort = QueryArguments.create(context, service.getTable().tableSchema().tableMetadata(), service.getItemType());
+            boolean scan = !partitionAndSort.hasPartitionKey();
             if (methodName.startsWith("count")) {
+                if (scan) {
+                    return unwrapIfRequired(service.countUsingScan(partitionAndSort.generateScan(context, conversionService)), context);
+                }
                 if (partitionAndSort.isCustomized()) {
                     return unwrapIfRequired(service.countUsingQuery(partitionAndSort.generateQuery(context, conversionService)), context);
                 }
                 return unwrapIfRequired(service.count(partitionAndSort.getPartitionValue(context.getParameters()), partitionAndSort.getSortValue(context.getParameters())), context);
             }
             if (methodName.startsWith("delete")) {
+                if (scan) {
+                    return unwrapIfRequired(service.deleteAll(service.scan(partitionAndSort.generateScan(context, conversionService))), context);
+                }
                 if (partitionAndSort.isCustomized()) {
                     return unwrapIfRequired(service.deleteAll(service.query(partitionAndSort.generateQuery(context, conversionService))), context);
                 }
                 Optional<ItemArgument> maybeItemArgument = ItemArgument.findItemArgument(service.getItemType(), context);
                 return unwrapIfRequired(handleDelete(service, context, maybeItemArgument), context);
+            }
+            if (scan) {
+                return unwrapIfRequired(service.scan(partitionAndSort.generateScan(context, conversionService)), context);
             }
             if (partitionAndSort.isCustomized()) {
                 return unwrapIfRequired(service.query(partitionAndSort.generateQuery(context, conversionService)), context);

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/main/java/com/agorapulse/micronaut/amazon/awssdk/dynamodb/AsyncDynamoDbServiceIntroduction.java
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/main/java/com/agorapulse/micronaut/amazon/awssdk/dynamodb/AsyncDynamoDbServiceIntroduction.java
@@ -200,6 +200,10 @@ public class AsyncDynamoDbServiceIntroduction implements DynamoDbServiceIntroduc
         if (methodName.startsWith("query") || methodName.startsWith("scan") || methodName.startsWith("findAll") || methodName.startsWith("list") || methodName.startsWith("count") || methodName.startsWith("delete")) {
             QueryArguments partitionAndSort = QueryArguments.create(context, service.getTable().tableSchema().tableMetadata(), service.getItemType());
             boolean scan = !partitionAndSort.hasPartitionKey();
+            if (scan && !methodName.startsWith("scan") && !partitionAndSort.hasScanIntent()) {
+                throw new UnsupportedOperationException("Method " + context.getExecutableMethod().getTargetMethod()
+                    + " has no @PartitionKey and no scan intent - annotate an argument with @Filter, @Limit, @Page or @LastEvaluatedKey, or name the method 'scan...' to scan the whole table");
+            }
             if (methodName.startsWith("count")) {
                 if (scan) {
                     return unwrapIfRequired(service.countUsingScan(partitionAndSort.generateScan(context, conversionService)), context);

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/main/java/com/agorapulse/micronaut/amazon/awssdk/dynamodb/util/QueryArguments.java
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/main/java/com/agorapulse/micronaut/amazon/awssdk/dynamodb/util/QueryArguments.java
@@ -224,6 +224,11 @@ public class QueryArguments {
         };
     }
 
+    /**
+     * Build the scan definition for a partition-less finder from its annotations: index, consistency, filters and
+     * pagination ({@code @Limit}, {@code @Page}, {@code @LastEvaluatedKey}). A sort key and descending order are not
+     * applied because a scan cannot honour them.
+     */
     public <T> Consumer<ScanBuilder<T>> generateScan(MethodInvocationContext<Object, Object> context, ConversionService conversionService) {
         return s -> {
             if (index != null) {

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/main/java/com/agorapulse/micronaut/amazon/awssdk/dynamodb/util/QueryArguments.java
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/main/java/com/agorapulse/micronaut/amazon/awssdk/dynamodb/util/QueryArguments.java
@@ -20,6 +20,7 @@ package com.agorapulse.micronaut.amazon.awssdk.dynamodb.util;
 import com.agorapulse.micronaut.amazon.awssdk.dynamodb.annotation.*;
 import com.agorapulse.micronaut.amazon.awssdk.dynamodb.builder.Builders;
 import com.agorapulse.micronaut.amazon.awssdk.dynamodb.builder.QueryBuilder;
+import com.agorapulse.micronaut.amazon.awssdk.dynamodb.builder.ScanBuilder;
 import io.micronaut.aop.MethodInvocationContext;
 import io.micronaut.core.async.publisher.Publishers;
 import io.micronaut.core.convert.ConversionService;
@@ -53,6 +54,7 @@ public class QueryArguments {
     private Argument<?> lastEvaluatedKey;
     private Argument<?> limit;
     private Argument<?> page;
+    private boolean hasBareFilterArgument;
 
     public static <T> QueryArguments create(MethodInvocationContext<Object, Object> context, TableMetadata tableMetadata, Class<T> itemType) {
         QueryArguments queryArguments = new QueryArguments();
@@ -102,12 +104,17 @@ public class QueryArguments {
             ) {
                 queryArguments.page = argument;
             } else {
+                if (!argument.isAnnotationPresent(Filter.class)) {
+                    queryArguments.hasBareFilterArgument = true;
+                }
                 String name = FilterArgument.getArgumentName(argument);
                 queryArguments.filters.computeIfAbsent(name, argName -> new FilterArgument()).fill(argument);
             }
         }
 
-        if (!queryArguments.isValid()) {
+        // A method without a partition key is served by a scan, but only when every remaining argument is an
+        // explicit @Filter - a bare unannotated argument is more likely a forgotten @PartitionKey than a scan filter.
+        if (queryArguments.partitionKey == null && queryArguments.hasBareFilterArgument) {
             throw new UnsupportedOperationException("Method needs to have at least one argument annotated with @PartitionKey or with called 'partition'");
         }
 
@@ -141,7 +148,7 @@ public class QueryArguments {
     }
 
 
-    boolean isValid() {
+    public boolean hasPartitionKey() {
         return partitionKey != null;
     }
 
@@ -213,6 +220,51 @@ public class QueryArguments {
 
             if (page != null) {
                 q.page(conversionService.convertRequired(context.getParameters().get(page.getName()).getValue(), Integer.class));
+            }
+        };
+    }
+
+    public <T> Consumer<ScanBuilder<T>> generateScan(MethodInvocationContext<Object, Object> context, ConversionService conversionService) {
+        return s -> {
+            if (index != null) {
+                s.index(index);
+            }
+
+            if (consistent) {
+                s.consistent(Builders.Read.READ);
+            }
+
+            if (!filters.isEmpty()) {
+                filters.forEach((name, filter) -> {
+                    Object firstValue = context.getParameters().get(filter.getFirstArgument().getName()).getValue();
+                    Object secondValue = filter.getSecondArgument() == null ? null : context.getParameters().get(filter.getSecondArgument().getName()).getValue();
+
+                    if (firstValue == null && !filter.isRequired()) {
+                        return;
+                    }
+
+                    s.filter(f -> filter.getOperator().apply(
+                        f,
+                        name,
+                        firstValue,
+                        secondValue)
+                    );
+                });
+            }
+
+            if (lastEvaluatedKey != null) {
+                Object exclusiveStartKey = context.getParameters().get(lastEvaluatedKey.getName()).getValue();
+                if (exclusiveStartKey != null) {
+                    s.lastEvaluatedKey(exclusiveStartKey);
+                }
+            }
+
+            if (limit != null) {
+                s.limit(conversionService.convertRequired(context.getParameters().get(limit.getName()).getValue(), Integer.class));
+            }
+
+            if (page != null) {
+                s.page(conversionService.convertRequired(context.getParameters().get(page.getName()).getValue(), Integer.class));
             }
         };
     }

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/main/java/com/agorapulse/micronaut/amazon/awssdk/dynamodb/util/QueryArguments.java
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/main/java/com/agorapulse/micronaut/amazon/awssdk/dynamodb/util/QueryArguments.java
@@ -280,4 +280,13 @@ public class QueryArguments {
     public boolean isCustomized() {
         return index != null || consistent || descending || !filters.isEmpty() || sortKey != null && sortKey.getOperator() != Filter.Operator.EQ || lastEvaluatedKey != null || limit != null || page != null;
     }
+
+    /**
+     * Whether the method explicitly asks to scan through its arguments - a filter, pagination, an index or a
+     * consistency requirement. A partition-less method without any such intent (and not named {@code scan...}) is
+     * rejected instead of silently scanning the whole table.
+     */
+    public boolean hasScanIntent() {
+        return index != null || consistent || !filters.isEmpty() || lastEvaluatedKey != null || limit != null || page != null;
+    }
 }

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/DynamoDBEntityService.java
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/DynamoDBEntityService.java
@@ -300,6 +300,22 @@ public interface DynamoDBEntityService {
 
     int countAllByNumber(@PartitionKey String parentId, Integer number);
 
+    List<DynamoDBEntity> scanAll();
+
+    List<DynamoDBEntity> scanAllByNumberGreaterThan(
+        @Filter(value = Filter.Operator.GT, name = "number") int number
+    );
+
+    List<DynamoDBEntity> scanAllByNumberGreaterThan(
+        @Filter(value = Filter.Operator.GT, name = "number") int number,
+        @LastEvaluatedKey DynamoDBEntity lastEvaluatedKey,
+        @Limit int limit
+    );
+
+    int countScannedByNumberGreaterThan(
+        @Filter(value = Filter.Operator.GT, name = "number") int number
+    );
+
 
 // tag::footer[]
 }

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/DynamoDBEntityService.java
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/DynamoDBEntityService.java
@@ -302,6 +302,8 @@ public interface DynamoDBEntityService {
 
     List<DynamoDBEntity> scanAll();
 
+    List<DynamoDBEntity> findAllInTable();
+
     List<DynamoDBEntity> scanAllByNumberGreaterThan(
         @Filter(value = Filter.Operator.GT, name = "number") int number
     );

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/ScanOnDeclarativeServiceTest.java
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/ScanOnDeclarativeServiceTest.java
@@ -1,0 +1,88 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright 2018-2026 Agorapulse.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.agorapulse.micronaut.amazon.awssdk.dynamodb;
+
+import com.agorapulse.micronaut.amazon.awssdk.core.client.ClientBuilderProvider;
+import io.micronaut.context.annotation.Property;
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@MicronautTest
+@Property(name = "test.table.name", value = "DynamoDBScanTest")
+@Property(name = "aws.dynamodb.client", value = ClientBuilderProvider.AWS_CRT)
+@Property(name = "aws.dynamodb.async-client", value = ClientBuilderProvider.AWS_CRT)
+public class ScanOnDeclarativeServiceTest {
+
+    private static final Instant REFERENCE_DATE = Instant.ofEpochMilli(1358487600000L);
+
+    @Inject DynamoDBEntityService s;
+
+    @Test
+    public void declarativeScanWithoutPartitionKey() {
+        s.save(createEntity("1", "1", 1));
+        s.save(createEntity("1", "2", 1));
+        s.save(createEntity("1", "3", 2));
+        s.save(createEntity("2", "1", 2));
+        s.save(createEntity("2", "2", 3));
+        s.save(createEntity("2", "3", 3));
+        s.save(createEntity("2", "4", null));
+
+        // scans span the whole table, across every partition
+        assertEquals(7, s.scanAll().size());
+
+        // the @Filter is applied server-side; the null-number entity is not matched
+        assertEquals(4, s.scanAllByNumberGreaterThan(1).size());
+        assertEquals(2, s.scanAllByNumberGreaterThan(2).size());
+        assertEquals(4, s.countScannedByNumberGreaterThan(1));
+
+        // @Limit + @LastEvaluatedKey page through the whole table without overlap
+        List<DynamoDBEntity> firstPage = s.scanAllByNumberGreaterThan(1, null, 2);
+        assertEquals(2, firstPage.size());
+
+        List<DynamoDBEntity> secondPage = s.scanAllByNumberGreaterThan(1, firstPage.get(firstPage.size() - 1), 2);
+        assertEquals(2, secondPage.size());
+
+        Set<String> firstKeys = firstPage.stream().map(ScanOnDeclarativeServiceTest::key).collect(Collectors.toSet());
+        assertTrue(secondPage.stream().map(ScanOnDeclarativeServiceTest::key).noneMatch(firstKeys::contains));
+    }
+
+    private static String key(DynamoDBEntity entity) {
+        return entity.getParentId() + "/" + entity.getId();
+    }
+
+    private DynamoDBEntity createEntity(String parentId, String id, Integer number) {
+        DynamoDBEntity entity = new DynamoDBEntity();
+        entity.setParentId(parentId);
+        entity.setId(id);
+        entity.setRangeIndex("range-" + id);
+        entity.setDate(Date.from(REFERENCE_DATE));
+        entity.setNumber(number);
+        return entity;
+    }
+
+}

--- a/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/ScanOnDeclarativeServiceTest.java
+++ b/subprojects/micronaut-amazon-awssdk-dynamodb/src/test/groovy/com/agorapulse/micronaut/amazon/awssdk/dynamodb/ScanOnDeclarativeServiceTest.java
@@ -30,6 +30,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @MicronautTest
@@ -69,6 +70,12 @@ public class ScanOnDeclarativeServiceTest {
 
         Set<String> firstKeys = firstPage.stream().map(ScanOnDeclarativeServiceTest::key).collect(Collectors.toSet());
         assertTrue(secondPage.stream().map(ScanOnDeclarativeServiceTest::key).noneMatch(firstKeys::contains));
+    }
+
+    @Test
+    public void partitionlessFinderWithoutScanIntentIsRejected() {
+        UnsupportedOperationException e = assertThrows(UnsupportedOperationException.class, () -> s.findAllInTable());
+        assertTrue(e.getMessage().contains("no scan intent"));
     }
 
     private static String key(DynamoDBEntity entity) {


### PR DESCRIPTION
## Summary

A declarative `@Service` finder previously had to carry a `@PartitionKey` (or be given an explicit `@Scan(Function)`); a method with neither was rejected. That makes a full-table scan by unindexed attributes only expressible through a hand-written `ScanFunction`, even though the same `@Filter` / `@Limit` / `@LastEvaluatedKey` annotations already exist for queries.

This adds an **annotation-driven scan**: when a `query` / `scan` / `findAll` / `list` / `count` / `delete` finder has **no partition key**, it is served by a table scan that applies the method's annotations, mirroring the query path.

```java
// no @PartitionKey -> scans the whole table, filter/limit/cursor applied server-side
List<DynamoDBEntity> scanAllByNumberGreaterThan(
    @Filter(value = Filter.Operator.GT, name = "number") int number,
    @LastEvaluatedKey DynamoDBEntity lastEvaluatedKey,
    @Limit int limit
);
```

## Explicit intent required (no accidental scans)

A partition-less finder scans **only when the intent is explicit**, so a forgotten `@PartitionKey` cannot silently turn into an expensive full-table scan:

- the method name starts with `scan`, **or**
- the method carries a scan annotation: `@Filter`, `@Limit`, `@Page`, `@LastEvaluatedKey`, `@Index` or `@Consistent`.

A partition-less finder with neither is rejected with a message pointing at both options.

## Changes

- **`QueryArguments`** — add `hasPartitionKey()`, `hasScanIntent()` and `generateScan()` (mirrors `generateQuery`: index, consistent, filters, `lastEvaluatedKey`, `limit`, `page`; no sort/descending, which a scan cannot honour). A partition-less method with a bare, unannotated argument is still rejected as a likely forgotten `@PartitionKey`. A null `@LastEvaluatedKey` value is treated as "from the beginning".
- **`AsyncDynamoDbServiceIntroduction`** — recognise the `scan` name prefix and, when there is no partition key, either reject (no explicit intent) or route to `service.scan(...)` / `countUsingScan(...)` / `deleteAll(service.scan(...))`. `@Scan(Function)` methods keep their existing precedence.

## Compatibility

Additive. Every existing finder carries a `@PartitionKey`, so it still takes the query path unchanged. The existing "unsupported method" behaviour is preserved: a partition-less `findAll(String, String)` with bare arguments still throws the same message (covered by `DefaultDynamoDBServiceSpec`).

## Tests

`ScanOnDeclarativeServiceTest` (isolated table) covers a filtered scan spanning multiple partitions, `countScannedBy…`, a full `scanAll()`, `@Limit` + `@LastEvaluatedKey` paging with no overlap between pages, and rejection of a partition-less finder that has no scan intent. Existing DynamoDB suites and the module quality gates pass (build requires JVM 25).

## Docs

The DynamoDB guide's *Scanning* section documents the annotation-driven scan and the explicit-intent rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U2HnRGMYcCLobT7s6DCFGq